### PR TITLE
Add issue template for reporting bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,65 @@
+name: Bug Report
+description: Create a report with a procedure for reproducing the bug
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: To Reproduce
+      description: Steps to reproduce the behavior
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: A clear and concise description of what you expected to happen
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Your Environment
+      description: |
+        - ThinBridge version:
+        - ThinBridge browser addon/extension version: See chrome://extensions (Chrome), about:addons (Firefox)
+
+        Tip: If you hit the problem with older ThinBridge version, try latest version first.
+      value: |
+        - ThinBridge version:
+        - ThinBridge Chrome extension version:
+        - ThinBridge Edge extension version:
+        - ThinBridge Firefox addon version:
+      render: markdown
+    validations:
+      required: true
+  - type: textarea
+    id: configuration
+    attributes:
+      label: Your Configuration
+      description: |
+        Write your ThinBridgeBHO.ini  configuration. Minimum reproducible ThinBridgeBHO.ini is recommended.
+      render: ini
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Your TRACE log (IE)
+      description: Write your TRACE log here
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: addtional-context
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here.
+    validations:
+      required: false


### PR DESCRIPTION
# Which issue(s) this PR fixes:

Followup PR for #12


# What this PR does / why we need it:

After merged https://github.com/ThinBridge/ThinBridge/pull/12,
there is no issue template for reporting bugs.(need to use Open a blank issue)

![image](https://user-images.githubusercontent.com/225841/206951754-97addcb8-2ed9-4ab6-a4ee-b594dcfd6634.png)


# How to verify the fixed issue:

Added issue template for reporting bugs.

## The steps to verify:

1. access issue https://github.com/ThinBridge/ThinBridge/issues
2. select "Bug Report" temlate

## Expected result:

Here is the expected screenshots:

![image](https://user-images.githubusercontent.com/225841/206952084-a1260c4a-2b1c-4658-9a87-150bd576bf0b.png)

![image](https://user-images.githubusercontent.com/225841/206952171-bf60ebed-db73-461d-9b76-4dc2576daeac.png)
