### PR TITLE
github workflows: fix warning about node 12 in build and assets

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -5,7 +5,7 @@ jobs:
     runs-on: [ windows-2019 ]
     steps:
       - uses: actions/checkout@v3
-      - uses: microsoft/setup-msbuild@v1.0.2
+      - uses: microsoft/setup-msbuild@v1.2
       - name: Compile x86
         run: msbuild /p:Platform=Win32 /p:Configuration=Release
       - name: Compile x64

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -4,7 +4,7 @@ jobs:
   build:
     runs-on: [ windows-2019 ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: microsoft/setup-msbuild@v1.0.2
       - name: Compile x86
         run: msbuild /p:Platform=Win32 /p:Configuration=Release
@@ -17,21 +17,21 @@ jobs:
       - name: Make Installer (x64)
         run: iscc.exe ThinBridgeX64.iss
       - name: Upload Binaries
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Binaries
           path: |
             Release/*.exe
             Release/*.dll
       - name: Upload Installer
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Installers
           path: SetupOutput/*.exe
   assets:
     runs-on: [ ubuntu-latest ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build Testing Extensions
         run: |
           cp webextension/edge/manifest.json.dev webextension/edge/manifest.json
@@ -40,12 +40,12 @@ jobs:
           make -C webextension/chrome
           make -C webextension/firefox
       - name: Upload Extensions
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: WebExtensions
           path: webextension/*/*.zip
       - name: Upload GPO Templates
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Templates
           path: Resources/GPO/*.adm*


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

Node 12 based action is deprecated. We need to migrate it.

![image](https://user-images.githubusercontent.com/225841/207279377-7685c385-90ad-4ec1-a3be-e4cdd20981bb.png)

# How to verify the fixed issue:

## The steps to verify:

See GitHub actions already executed in the forked repository.

![image](https://user-images.githubusercontent.com/225841/207303876-59b2035d-104a-4186-8f07-e87e8fc044de.png)

https://github.com/kenhys/ThinBridge/actions/runs/3684063646 logs.

## Expected result:

There are no node 12 warnings in build and assets target.


