### PR TITLE
Bump version for release

### DIFF
--- a/BHORedirector/BHORedirector.rc
+++ b/BHORedirector/BHORedirector.rc
@@ -58,8 +58,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 4,2,0,0
- PRODUCTVERSION 4,2,0,0
+ FILEVERSION 4,2,0,1
+ PRODUCTVERSION 4,2,0,1
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -76,12 +76,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "ThinBridge"
             VALUE "FileDescription", "ThinBridge"
-            VALUE "FileVersion", "4.2.0.0"
+            VALUE "FileVersion", "4.2.0.1"
             VALUE "InternalName", "ThinBridgeBHO.dll"
             VALUE "LegalCopyright", "ThinBridge All rights reserved."
             VALUE "OriginalFilename", "ThinBridgeBHO.dll"
             VALUE "ProductName", "ThinBridge Browser Helper"
-            VALUE "ProductVersion", "4.2.0.0"
+            VALUE "ProductVersion", "4.2.0.1"
         END
     END
     BLOCK "VarFileInfo"

--- a/ThinBridgeX64.iss
+++ b/ThinBridgeX64.iss
@@ -3,8 +3,8 @@
 [Setup]
 AppName=ThinBridge
 AppVerName=ThinBridge
-VersionInfoVersion=4.0.2.5
-AppVersion=4.0.2.5
+VersionInfoVersion=4.0.2.6
+AppVersion=4.0.2.6
 AppMutex=ThinBridgeSetup
 ;DefaultDirName=C:\ThinBridge
 DefaultDirName={code:GetProgramFiles}\ThinBridge

--- a/ThinBridgeX86.iss
+++ b/ThinBridgeX86.iss
@@ -3,8 +3,8 @@
 [Setup]
 AppName=ThinBridge
 AppVerName=ThinBridge
-VersionInfoVersion=4.0.2.5
-AppVersion=4.0.2.5
+VersionInfoVersion=4.0.2.6
+AppVersion=4.0.2.6
 AppMutex=ThinBridgeSetup
 ;DefaultDirName=C:\ThinBridge
 DefaultDirName={code:GetProgramFiles}\ThinBridge


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

This just updates the version number.

# How to verify the fixed issue:

Install ThinBridge to a verification environment and see the installed version.

## The steps to verify:

1. Install ThinBridge with the installer.
2. Go to installed apps list of Windows, and see the installed version of ThinBridge.
3. Start Internet Explorer.
4. Go to IE's addons manager and see the installed version of ThinBridge Browser Helper.

## Expected result:

* The installed version of ThinBridge is 4.2.0.1.
* The installed ThinBridge Browser Helper is 4.0.2.6.