### PR TITLE
Add script to start legacy Internet Explorer on newer environment

### DIFF
--- a/doc/verify/Start Internet Explorer.vbs
+++ b/doc/verify/Start Internet Explorer.vbs
@@ -1,0 +1,1 @@
+CreateObject("InternetExplorer.Application").Visible=true

--- a/doc/verify/windows-10-21H2/main.tf
+++ b/doc/verify/windows-10-21H2/main.tf
@@ -498,6 +498,10 @@ resource "local_file" "playbook" {
       become_user: "管理者"
       win_regmerge:
         path: 'C:\Users\Public\disable-protect-mode.reg'
+    - name: "Copy script to start legacy Internet Explorer"
+      win_copy:
+        src: '../../Start Internet Explorer.vbs'
+        dest: '%Public%\Desktop\'
 EOL
 }
 

--- a/doc/verify/windows-11-22H2/main.tf
+++ b/doc/verify/windows-11-22H2/main.tf
@@ -510,6 +510,10 @@ resource "local_file" "playbook" {
       become_user: "管理者"
       win_regmerge:
         path: 'C:\Users\Public\disable-protect-mode.reg'
+    - name: "Copy script to start legacy Internet Explorer"
+      win_copy:
+        src: '../../Start Internet Explorer.vbs'
+        dest: '%Public%\Desktop\'
 EOL
 }
 


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

On newer version Windows 11, iexplore.exe works just as a redirector to Edge. This PR adds a script to start legacy IE instead of Edge for convenience.

# How to verify the fixed issue:

Setup verification environments and double-click "Start Internet Explorer.vbs" on the desktop, then you'll see the legacy IE.

## The steps to verify:

1. `cd` to `windows-11-22H2`.
2. Run `make` to setup the environment.
3. Log into the environment.
4. Double-click the file "Start Internet Explorer.vbs" on the desktop.

## Expected result:

Legacy Internet Explorer appears.
