### PR TITLE
Unpromisify for old Edge like 94

### DIFF
--- a/webextension/chrome/background.js
+++ b/webextension/chrome/background.js
@@ -171,7 +171,7 @@ const ThinBridgeTalkClient = {
   },
 
   match(section, url, namedSections) {
-    for (const name of section.ExcludeGroups) {
+    for (const name of (section.ExcludeGroups || [])) {
       const foreignSection = namedSections[name.toLowerCase()];
       //console.log(`* Referring exlude group ${name}: ${JSON.stringify(foreignSection && foreignSection.Patterns)}`);
       if (!foreignSection)

--- a/webextension/edge/background.js
+++ b/webextension/edge/background.js
@@ -171,7 +171,7 @@ const ThinBridgeTalkClient = {
   },
 
   match(section, url, namedSections) {
-    for (const name of section.ExcludeGroups) {
+    for (const name of (section.ExcludeGroups || [])) {
       const foreignSection = namedSections[name.toLowerCase()];
       //console.log(`* Referring exlude group ${name}: ${JSON.stringify(foreignSection && foreignSection.Patterns)}`);
       if (!foreignSection)

--- a/webextension/edge/background.js
+++ b/webextension/edge/background.js
@@ -86,7 +86,7 @@ const ThinBridgeTalkClient = {
   configure() {
     const query = new String('C ' + BROWSER);
 
-    chrome.runtime.sendNativeMessage(SERVER_NAME, query).then(resp => {
+    chrome.runtime.sendNativeMessage(SERVER_NAME, query, resp => {
       if (chrome.runtime.lastError) {
         console.log('Cannot fetch config', JSON.stringify(chrome.runtime.lastError));
         return;
@@ -151,7 +151,7 @@ const ThinBridgeTalkClient = {
    * * Request Example: "Q edge https://example.com/".
    */
   redirect(url, tabId, closeTab) {
-    chrome.tabs.get(tabId).then(tab => {
+    chrome.tabs.get(tabId, tab => {
       if (chrome.runtime.lastError) {
         console.log(`* Ignore prefetch request`);
         return;
@@ -162,7 +162,7 @@ const ThinBridgeTalkClient = {
       }
 
       const query = new String('Q ' + BROWSER + ' ' + url);
-      chrome.runtime.sendNativeMessage(SERVER_NAME, query).then(_resp => {
+      chrome.runtime.sendNativeMessage(SERVER_NAME, query, _resp => {
         if (closeTab) {
           chrome.tabs.remove(tabId);
         }
@@ -297,7 +297,7 @@ const ThinBridgeTalkClient = {
 
   /* Handle startup tabs preceding to onBeforeRequest */
   handleStartup(config) {
-    chrome.tabs.query({}).then(tabs => {
+    chrome.tabs.query({}, tabs => {
       tabs.forEach((tab) => {
         const url = tab.url || tab.pendingUrl;
         console.log(`handleStartup ${url} (tab=${tab.id})`);
@@ -323,7 +323,7 @@ const ThinBridgeTalkClient = {
     /* Call executeScript() to stop the page loading immediately.
      * Then let the tab go back to the previous page.
      */
-    chrome.tabs.executeScript(tabId, {code: 'window.stop()', runAt: 'document_start'}).then(() => {
+    chrome.tabs.executeScript(tabId, {code: 'window.stop()', runAt: 'document_start'}, () => {
       chrome.tabs.goBack(tabId);
     });
   },
@@ -381,7 +381,7 @@ const ResourceCap = {
       return;
     }
 
-    chrome.tabs.query({}).then(tabs => {
+    chrome.tabs.query({}, tabs => {
       const ntabs = ResourceCap.count(tabs);
       console.log(`* Perform resource check (ntabs=${ntabs})`);
       ResourceCap.check(details.tabId, ntabs);
@@ -390,14 +390,14 @@ const ResourceCap = {
 
   check(tabId, ntabs) {
     const query = new String(`R ${BROWSER} ${ntabs}`);
-    chrome.runtime.sendNativeMessage(SERVER_NAME, query).then(resp => {
+    chrome.runtime.sendNativeMessage(SERVER_NAME, query, resp => {
       // Need this to support ThinBridge v4.0.2.3 (or before)
       if (chrome.runtime.lastError) {
         return;
       }
 
       if (resp.closeTab) {
-        chrome.tabs.remove(tabId).then(() => {
+        chrome.tabs.remove(tabId, () => {
           if (chrome.runtime.lastError) {
             console.log(`* ${chrome.runtime.lastError}`);
             return;

--- a/webextension/firefox/background.js
+++ b/webextension/firefox/background.js
@@ -171,7 +171,7 @@ const ThinBridgeTalkClient = {
   },
 
   match(section, url, namedSections) {
-    for (const name of section.ExcludeGroups) {
+    for (const name of (section.ExcludeGroups || [])) {
       const foreignSection = namedSections[name.toLowerCase()];
       //console.log(`* Referring exlude group ${name}: ${JSON.stringify(foreignSection && foreignSection.Patterns)}`);
       if (!foreignSection)


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

It was announced that WebExtensions API on Manifest V3 addons supports Promise, but APIs don't return Promise actually on old versions like Edge 94.
Thus we need to rollback changes using Promise to using old callback style.

# How to verify the fixed issue:

Install this version and verify it is works as expected.

## The steps to verify:

1. Run `cd webextension/edge && make` to create zip file.
2. Copy ThinBridgeEdgeDev.zip to the verification environment and unzip it.
3. Install Edge 94.
4. Install policy template of Edge.
5. Start group policy editor.
6. Deactivate auto update of Edge: Administrative Templates → Microsoft Edge Update → Applications → Microsoft Edge → Update policy override → Enabled: Updates disabled
7. Install the development version via GPO, like steps described at https://gitlab.com/clear-code/browserselector/-/tree/master/#notes-for-manifest-v3
8. Create `C:\Program Files\ThinBridge\ThinBridgeBHO.ini` as:
   ```
   [Chrome]
   @BROWSER_PATH:
   @TOP_PAGE_ONLY
   @REDIRECT_PAGE_ACTION:0
   @CLOSE_TIMEOUT:3
   *://example.com/*
   
   [Default]
   @BROWSER_PATH:Edge
   @TOP_PAGE_ONLY
   @REDIRECT_PAGE_ACTION:0
   @CLOSE_TIMEOUT:3
   ```
9. Start Edge 94.
10. Open new tab and load `https://example.com/`.

## Expected result:

The tab is redirected to Chrome.
