### PR TITLE
Bump addon version for a new release with bugfixes

### DIFF
--- a/webextensions/chrome/Makefile
+++ b/webextensions/chrome/Makefile
@@ -16,5 +16,5 @@ dev: $(FILES)
 	rm -rf dev
 	mkdir -p dev
 	cp -R manifest.json misc background.js dev/
-	sed -i -E -e 's/ThinBridge/ThinBridge Enterrpise Developer Edition/g' dev/manifest.json
+	sed -i -E -e 's/ThinBridge/ThinBridge Enterprise Developer Edition/g' dev/manifest.json
 	cd dev && zip -9 - $(FILES) > ../ThinBridgeChromeDev.zip

--- a/webextensions/chrome/manifest.json
+++ b/webextensions/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 3,
 	"name": "ThinBridge",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"description": "ThinBridge for Chrome",
 	"permissions": [
 		"nativeMessaging",

--- a/webextensions/edge/Makefile
+++ b/webextensions/edge/Makefile
@@ -17,5 +17,5 @@ dev: $(FILES)
 	rm -rf dev
 	mkdir -p dev
 	cp -R manifest.json misc _locales background.js dev/
-	sed -i -E -e 's/ThinBridge/ThinBridge Enterrpise Developer Edition/g' dev/_locales/*/messages.json
+	sed -i -E -e 's/ThinBridge/ThinBridge Enterprise Developer Edition/g' dev/_locales/*/messages.json
 	cd dev && zip -9 - $(FILES) > ../ThinBridgeEdgeDev.zip

--- a/webextensions/edge/manifest.json
+++ b/webextensions/edge/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 3,
 	"name": "__MSG_extName__",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"description": "__MSG_extDescription__",
 	"permissions": [
 		"nativeMessaging",

--- a/webextensions/firefox/manifest.json
+++ b/webextensions/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 2,
 	"name": "ThinBridge",
-	"version": "1.6.0",
+	"version": "1.6.1",
 	"description": "ThinBridge for Firefox",
 	"permissions": [
 		"nativeMessaging",


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

There are some fixes on Manifest V3 version addons and fixed development versions need to be released for testing.

# How to verify the fixed issue:

Load the development version and confirm its version number is updated.

## The steps to verify:

1. `cd webextension*`
2. `(cd chrome && make dev) && (cd edge && make dev)`
3. Start Chrome and go to chrome://extensions
4. Load unpacked from webextension*/chrome/dev
5. Start Edge and go to edge://extensions
6. Load unpacked from webextension*/edge/dev

## Expected result:

They are loaded with the version 2.0.1.
