### PR TITLE
Ignore install error of Edge

### DIFF
--- a/doc/verify/windows-10-1809/main.tf
+++ b/doc/verify/windows-10-1809/main.tf
@@ -531,6 +531,7 @@ resource "local_file" "playbook" {
     - name: Install Edge from Installer
       when: not "${var.edge-installer-download-url}" == ""
       win_command: 'msiexec /i C:\Users\Public\EdgeSetup.msi /passive /norestart'
+      ignore_erros: yes
     - name: Disable Edge Update Service (edgeupdate)
       when: not "${var.edge-installer-download-url}" == ""
       win_service:

--- a/doc/verify/windows-10-21H2/main.tf
+++ b/doc/verify/windows-10-21H2/main.tf
@@ -567,6 +567,7 @@ resource "local_file" "playbook" {
     - name: Install Edge from Installer
       when: not "${var.edge-installer-download-url}" == ""
       win_command: 'msiexec /i C:\Users\Public\EdgeSetup.msi /passive /norestart'
+      ignore_erros: yes
     - name: Disable Edge Update Service (edgeupdate)
       when: not "${var.edge-installer-download-url}" == ""
       win_service:

--- a/doc/verify/windows-11-22H2/main.tf
+++ b/doc/verify/windows-11-22H2/main.tf
@@ -579,6 +579,7 @@ resource "local_file" "playbook" {
     - name: Install Edge from Installer
       when: not "${var.edge-installer-download-url}" == ""
       win_command: 'msiexec /i C:\Users\Public\EdgeSetup.msi /passive /norestart'
+      ignore_erros: yes
     - name: Disable Edge Update Service (edgeupdate)
       when: not "${var.edge-installer-download-url}" == ""
       win_service:


### PR DESCRIPTION
The errorlevel of the installer is not 0 even if it is successfully installed, so we need to ignore it.

# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

Just ignores installation error of Edge.

# How to verify the fixed issue:

Try to setup an verification environment.

## The steps to verify:

1. `cd doc/verify/windows-11-22H2` (for example)
2. `make`

## Expected result:

Ansible does not stop running after the installation step of Edge.