### PR TITLE
WIP: More logs for debugging on redirection by TBRedirector.exe

### DIFF
--- a/TBRedirector/TBRedirector.cpp
+++ b/TBRedirector/TBRedirector.cpp
@@ -95,7 +95,7 @@ BOOL CTBRedirectorApp::InitInstance()
 
 			if (!Command1.IsEmpty())
 			{
-				logmsg.Format(_T("Command1\t%s"), Command1);
+				logmsg.Format(_T("Command1\t%s"), static_cast<LPCTSTR>(Command1));
 				this->WriteDebugTraceDateTime(logmsg);
 				//URLかFilePathの場合は、強制的にm_CommandParamとする。
 				if (SBUtil::IsURL(Command1))

--- a/TBRedirector/TBRedirector.cpp
+++ b/TBRedirector/TBRedirector.cpp
@@ -119,7 +119,7 @@ BOOL CTBRedirectorApp::InitInstance()
 				}
 			}
 		}
-		logmsg.Format(_T("m_CommandParam\t%s"), m_CommandParam);
+		logmsg.Format(_T("m_CommandParam\t%s"), static_cast<LPCTSTR>(m_CommandParam));
 		this->WriteDebugTraceDateTime(logmsg);
 		if (m_CommandParam.IsEmpty())
 		{

--- a/TBRedirector/TBRedirector.cpp
+++ b/TBRedirector/TBRedirector.cpp
@@ -250,8 +250,6 @@ void CTBRedirectorApp::ExecRedirect(LPCTSTR lpURL)
 	if (bResultRedirectURL)
 	{
 		this->WriteDebugTraceDateTime(_T("Matched"));
-		logmsg.Format(_T("Command1\t%s"), Command1);
-		this->WriteDebugTraceDateTime(logmsg);
 		int iColMax = (int)arr_RedirectBrowserHit.GetCount();
 		if (iColMax < 1) {
 			this->WriteDebugTraceDateTime(_T("No hit"));

--- a/TBRedirector/TBRedirector.cpp
+++ b/TBRedirector/TBRedirector.cpp
@@ -121,8 +121,18 @@ BOOL CTBRedirectorApp::InitInstance()
 		}
 		logmsg.Format(_T("m_CommandParam\t%s"), m_CommandParam);
 		this->WriteDebugTraceDateTime(logmsg);
-		if (!m_CommandParam.IsEmpty())
+		if (m_CommandParam.IsEmpty())
+		{
+			this->WriteDebugTraceDateTime(_T("Empty parameter"));
+		}
+		else
+		{
 			this->ExecRedirect(m_CommandParam);
+		}
+	}
+	else
+	{
+		this->WriteDebugTraceDateTime(_T("No parameter"));
 	}
 
 #if !defined(_AFXDLL) && !defined(_AFX_NO_MFC_CONTROLS_IN_DIALOGS)

--- a/TBRedirector/TBRedirector.cpp
+++ b/TBRedirector/TBRedirector.cpp
@@ -341,7 +341,7 @@ void CTBRedirectorApp::ExecRedirect(LPCTSTR lpURL)
 			strDefBrowserName = GetDefaultBrowser();
 		}
 		strDefBrowserName = strDefBrowserName.MakeUpper();
-		logmsg.Format(_T("strDefBrowserName\t%s"), strDefBrowserName);
+		logmsg.Format(_T("strDefBrowserName\t%s"), static_cast<LPCTSTR>(strDefBrowserName));
 		this->WriteDebugTraceDateTime(logmsg);
 
 		//MS-Edge


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

This adds detailed logs to TBRedirector.exe for more easy debugging.

# How to verify the fixed issue:

Build the binary and run TBRedirector.exe with various params.

## The steps to verify:

1. Rename `TBo365URLSync.exe` to something other. If it exists ThinBridgeSetting.exe doesn't expose full configuration pages.
2. Start ThinBridgeSetting.exe.
3. Set redirection rules as:
    * Chrome: `*://example.com/`
    * Edge: `*://example.net/`
    * Default browser: IE
4. Save configs.
5. Open TRACE Log Monitor Window.
6. Start cmd.exe.
7. Run TBRedirector.exe with no parameter.
   * It should report "No parameter".
8. Run TBRedirector.exe with a blank text parameter `""`.
   * It should report "Empty parameter".
9. Run TBRedirector.exe with a path to nodepad.exe `"C:\Windows\notepad.exe"`
   * It should report "ExecRedirect: it is not a HTTP URL	C:\Windows\notepad.exe".
10. Run TBRedirector.exe with a path to missing file like `"c:\missing"`
   * It should report "ShellExecute with null command", "ShellExecute with open command" and "ShellExecute with explorer.exe".
11. Run TBRedirector.exe with a URL `https://example.com/`
   * It should report "Matched" and "Redirectiong...".
12. Run TBRedirector.exe with a URL `https://example.org/`
   * It should report "Not matched" and "Has default browser setting".

## Expected result:

TBRedirector.exe reports expected logs.
