### PR TITLE
Update verification environment to use sakura editor

### DIFF
--- a/doc/verify/windows-10-1809/main.tf
+++ b/doc/verify/windows-10-1809/main.tf
@@ -345,9 +345,15 @@ resource "local_file" "playbook" {
       win_chocolatey:
         name: chocolatey
         state: present
-    - name: Install EmEditor
+    - name: Install chocolatey-compatibility.extension to install legacy style package like SakuraEditor
       win_chocolatey:
-        name: emeditor
+        name: chocolatey-compatibility.extension
+        state: present
+        allow_empty_checksums: yes
+        ignore_checksums: yes
+    - name: Install SakuraEditor
+      win_chocolatey:
+        name: sakuraeditor
         state: present
         allow_empty_checksums: yes
         ignore_checksums: yes

--- a/doc/verify/windows-10-1809/main.tf
+++ b/doc/verify/windows-10-1809/main.tf
@@ -230,11 +230,18 @@ resource "local_file" "playbook" {
   filename = "ansible/playbook.yml"
   content  = <<EOL
 - hosts: windows
+  gather_facts: no
   become_method: runas
   vars:
     ansible_become_password: "${var.windows-password}"
     chrome_installer_download_url: "${var.chrome-installer-download-url}"
   tasks:
+    - name: Wait for reachable by polling after 'delay' until 'timeout'
+      ansible.builtin.wait_for_connection:
+          delay: 10
+          timeout: 300
+    - name: Gathering facts by setup module
+      setup:
     - name: Allow copy and paste to the UAC dialog
       win_regedit:
         key: HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\System

--- a/doc/verify/windows-10-21H2/main.tf
+++ b/doc/verify/windows-10-21H2/main.tf
@@ -381,9 +381,15 @@ resource "local_file" "playbook" {
       win_chocolatey:
         name: chocolatey
         state: present
-    - name: Install EmEditor
+    - name: Install chocolatey-compatibility.extension to install legacy style package like SakuraEditor
       win_chocolatey:
-        name: emeditor
+        name: chocolatey-compatibility.extension
+        state: present
+        allow_empty_checksums: yes
+        ignore_checksums: yes
+    - name: Install SakuraEditor
+      win_chocolatey:
+        name: sakuraeditor
         state: present
         allow_empty_checksums: yes
         ignore_checksums: yes

--- a/doc/verify/windows-10-21H2/main.tf
+++ b/doc/verify/windows-10-21H2/main.tf
@@ -266,11 +266,18 @@ resource "local_file" "playbook" {
   filename = "ansible/playbook.yml"
   content  = <<EOL
 - hosts: windows
+  gather_facts: no
   become_method: runas
   vars:
     ansible_become_password: "${var.windows-password}"
     chrome_installer_download_url: "${var.chrome-installer-download-url}"
   tasks:
+    - name: Wait for reachable by polling after 'delay' until 'timeout'
+      ansible.builtin.wait_for_connection:
+          delay: 10
+          timeout: 300
+    - name: Gathering facts by setup module
+      setup:
     - name: Allow copy and paste to the UAC dialog
       win_regedit:
         key: HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\System

--- a/doc/verify/windows-11-22H2/main.tf
+++ b/doc/verify/windows-11-22H2/main.tf
@@ -272,11 +272,18 @@ resource "local_file" "playbook" {
   filename = "ansible/playbook.yml"
   content  = <<EOL
 - hosts: windows
+  gather_facts: no
   become_method: runas
   vars:
     ansible_become_password: "${var.windows-password}"
     chrome_installer_download_url: "${var.chrome-installer-download-url}"
   tasks:
+    - name: Wait for reachable by polling after 'delay' until 'timeout'
+      ansible.builtin.wait_for_connection:
+          delay: 10
+          timeout: 300
+    - name: Gathering facts by setup module
+      setup:
     - name: Allow copy and paste to the UAC dialog
       win_regedit:
         key: HKLM:\Software\Microsoft\Windows\CurrentVersion\Policies\System

--- a/doc/verify/windows-11-22H2/main.tf
+++ b/doc/verify/windows-11-22H2/main.tf
@@ -387,9 +387,15 @@ resource "local_file" "playbook" {
       win_chocolatey:
         name: chocolatey
         state: present
-    - name: Install EmEditor
+    - name: Install chocolatey-compatibility.extension to install legacy style package like SakuraEditor
       win_chocolatey:
-        name: emeditor
+        name: chocolatey-compatibility.extension
+        state: present
+        allow_empty_checksums: yes
+        ignore_checksums: yes
+    - name: Install SakuraEditor
+      win_chocolatey:
+        name: sakuraeditor
         state: present
         allow_empty_checksums: yes
         ignore_checksums: yes


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

Currently chocolatey fails to install EmEditor silently, so I suggest switching to another editor ex. sakura editor.

BTW this PR contains another change to speed up the setup process skipping gathering facts also.

# How to verify the fixed issue:

Setup a verification environment and confirm it successfully finishes.

## The steps to verify:

1. `cd` to `doc/verify/windows-10-21H2` (for example)
2. Run `make` with a Microsoft account which can create virtual machines on Azure.

## Expected result:

The command successfully finishes without any error.