### PR TITLE
Copy policy templates correctly

### DIFF
--- a/doc/verify/windows-10-1809/main.tf
+++ b/doc/verify/windows-10-1809/main.tf
@@ -511,7 +511,7 @@ resource "local_file" "playbook" {
       win_command: xcopy /y C:\Users\Public\firefox_policy_templates\windows\* C:\Windows\PolicyDefinitions\
     - name: Install Firefox policy template (en-US locale)
       when: not "${var.firefox-policy-template-url}" == ""
-      win_command: xcopy /y C:\Users\Public\firefox_policy_templates\windows\en-US C:\Windows\PolicyDefinitions\en-US
+      win_command: xcopy /y C:\Users\Public\firefox_policy_templates\windows\en-US\* C:\Windows\PolicyDefinitions\en-US\
     - name: Install Google Chrome via Chocolatey
       when: chrome_installer_download_url | length == 0
       win_chocolatey:
@@ -564,10 +564,10 @@ resource "local_file" "playbook" {
       win_command: xcopy /y C:\Users\Public\chrome_policy_templates\windows\admx\* C:\Windows\PolicyDefinitions\
     - name: Install Google Chrome policy template (en-US locale)
       when: not "${var.chrome-policy-template-url}" == ""
-      win_command: xcopy /y C:\Users\Public\chrome_policy_templates\windows\admx\en-US C:\Windows\PolicyDefinitions\en-US
+      win_command: xcopy /y C:\Users\Public\chrome_policy_templates\windows\admx\en-US\* C:\Windows\PolicyDefinitions\en-US\
     - name: Install Google Chrome policy template (ja-JP locale)
       when: not "${var.chrome-policy-template-url}" == ""
-      win_command: xcopy /y C:\Users\Public\chrome_policy_templates\windows\admx\ja-JP C:\Windows\PolicyDefinitions\ja-JP
+      win_command: xcopy /y C:\Users\Public\chrome_policy_templates\windows\admx\ja-JP\* C:\Windows\PolicyDefinitions\ja-JP\
     - name: Download Edge installer
       when: not "${var.edge-installer-download-url}" == ""
       win_get_url:
@@ -613,10 +613,10 @@ resource "local_file" "playbook" {
       win_command: xcopy /y C:\Users\Public\MicrosoftEdgePolicyTemplates\windows\admx\* C:\Windows\PolicyDefinitions\
     - name: Install Edge policy template (en-US locale)
       when: not "${var.edge-policy-template-url}" == ""
-      win_command: xcopy /y C:\Users\Public\MicrosoftEdgePolicyTemplates\windows\admx\en-US C:\Windows\PolicyDefinitions\en-US
+      win_command: xcopy /y C:\Users\Public\MicrosoftEdgePolicyTemplates\windows\admx\en-US\* C:\Windows\PolicyDefinitions\en-US\
     - name: Install Edge policy template (ja-JP locale)
       when: not "${var.edge-policy-template-url}" == ""
-      win_command: xcopy /y C:\Users\Public\MicrosoftEdgePolicyTemplates\windows\admx\ja-JP C:\Windows\PolicyDefinitions\ja-JP
+      win_command: xcopy /y C:\Users\Public\MicrosoftEdgePolicyTemplates\windows\admx\ja-JP\* C:\Windows\PolicyDefinitions\ja-JP\
     - name: "Copy setup registry to join to a fake domain"
       win_copy:
         src: ../../join-to-fake-domain.reg

--- a/doc/verify/windows-10-21H2/main.tf
+++ b/doc/verify/windows-10-21H2/main.tf
@@ -649,10 +649,10 @@ resource "local_file" "playbook" {
       win_command: xcopy /y C:\Users\Public\MicrosoftEdgePolicyTemplates\windows\admx\* C:\Windows\PolicyDefinitions\
     - name: Install Edge policy template (en-US locale)
       when: not "${var.edge-policy-template-url}" == ""
-      win_command: xcopy /y C:\Users\Public\MicrosoftEdgePolicyTemplates\windows\admx\en-US C:\Windows\PolicyDefinitions\en-US
+      win_command: xcopy /y C:\Users\Public\MicrosoftEdgePolicyTemplates\windows\admx\en-US\* C:\Windows\PolicyDefinitions\en-US\
     - name: Install Edge policy template (ja-JP locale)
       when: not "${var.edge-policy-template-url}" == ""
-      win_command: xcopy /y C:\Users\Public\MicrosoftEdgePolicyTemplates\windows\admx\ja-JP C:\Windows\PolicyDefinitions\ja-JP
+      win_command: xcopy /y C:\Users\Public\MicrosoftEdgePolicyTemplates\windows\admx\ja-JP\* C:\Windows\PolicyDefinitions\ja-JP\
     - name: "Copy setup registry to join to a fake domain"
       win_copy:
         src: ../../join-to-fake-domain.reg

--- a/doc/verify/windows-10-21H2/main.tf
+++ b/doc/verify/windows-10-21H2/main.tf
@@ -547,7 +547,7 @@ resource "local_file" "playbook" {
       win_command: xcopy /y C:\Users\Public\firefox_policy_templates\windows\* C:\Windows\PolicyDefinitions\
     - name: Install Firefox policy template (en-US locale)
       when: not "${var.firefox-policy-template-url}" == ""
-      win_command: xcopy /y C:\Users\Public\firefox_policy_templates\windows\en-US C:\Windows\PolicyDefinitions\en-US
+      win_command: xcopy /y C:\Users\Public\firefox_policy_templates\windows\en-US\* C:\Windows\PolicyDefinitions\en-US\
     - name: Install Google Chrome via Chocolatey
       when: chrome_installer_download_url | length == 0
       win_chocolatey:
@@ -600,10 +600,10 @@ resource "local_file" "playbook" {
       win_command: xcopy /y C:\Users\Public\chrome_policy_templates\windows\admx\* C:\Windows\PolicyDefinitions\
     - name: Install Google Chrome policy template (en-US locale)
       when: not "${var.chrome-policy-template-url}" == ""
-      win_command: xcopy /y C:\Users\Public\chrome_policy_templates\windows\admx\en-US C:\Windows\PolicyDefinitions\en-US
+      win_command: xcopy /y C:\Users\Public\chrome_policy_templates\windows\admx\en-US\* C:\Windows\PolicyDefinitions\en-US\
     - name: Install Google Chrome policy template (ja-JP locale)
       when: not "${var.chrome-policy-template-url}" == ""
-      win_command: xcopy /y C:\Users\Public\chrome_policy_templates\windows\admx\ja-JP C:\Windows\PolicyDefinitions\ja-JP
+      win_command: xcopy /y C:\Users\Public\chrome_policy_templates\windows\admx\ja-JP\* C:\Windows\PolicyDefinitions\ja-JP\
     - name: Download Edge installer
       when: not "${var.edge-installer-download-url}" == ""
       win_get_url:

--- a/doc/verify/windows-11-22H2/main.tf
+++ b/doc/verify/windows-11-22H2/main.tf
@@ -653,10 +653,10 @@ resource "local_file" "playbook" {
       win_command: xcopy /y C:\Users\Public\MicrosoftEdgePolicyTemplates\windows\admx\* C:\Windows\PolicyDefinitions\
     - name: Install Edge policy template (en-US locale)
       when: not "${var.edge-policy-template-url}" == ""
-      win_command: xcopy /y C:\Users\Public\MicrosoftEdgePolicyTemplates\windows\admx\en-US C:\Windows\PolicyDefinitions\en-US
+      win_command: xcopy /y C:\Users\Public\MicrosoftEdgePolicyTemplates\windows\admx\en-US\* C:\Windows\PolicyDefinitions\en-US\
     - name: Install Edge policy template (ja-JP locale)
       when: not "${var.edge-policy-template-url}" == ""
-      win_command: xcopy /y C:\Users\Public\MicrosoftEdgePolicyTemplates\windows\admx\ja-JP C:\Windows\PolicyDefinitions\ja-JP
+      win_command: xcopy /y C:\Users\Public\MicrosoftEdgePolicyTemplates\windows\admx\ja-JP\* C:\Windows\PolicyDefinitions\ja-JP\
     - name: "Copy setup registry to join to a fake domain"
       win_copy:
         src: ../../join-to-fake-domain.reg

--- a/doc/verify/windows-11-22H2/main.tf
+++ b/doc/verify/windows-11-22H2/main.tf
@@ -551,7 +551,7 @@ resource "local_file" "playbook" {
       win_command: xcopy /y C:\Users\Public\firefox_policy_templates\windows\* C:\Windows\PolicyDefinitions\
     - name: Install Firefox policy template (en-US locale)
       when: not "${var.firefox-policy-template-url}" == ""
-      win_command: xcopy /y C:\Users\Public\firefox_policy_templates\windows\en-US C:\Windows\PolicyDefinitions\en-US
+      win_command: xcopy /y C:\Users\Public\firefox_policy_templates\windows\en-US\* C:\Windows\PolicyDefinitions\en-US\
     - name: Install Google Chrome via Chocolatey
       when: chrome_installer_download_url | length == 0
       win_chocolatey:
@@ -604,10 +604,10 @@ resource "local_file" "playbook" {
       win_command: xcopy /y C:\Users\Public\chrome_policy_templates\windows\admx\* C:\Windows\PolicyDefinitions\
     - name: Install Google Chrome policy template (en-US locale)
       when: not "${var.chrome-policy-template-url}" == ""
-      win_command: xcopy /y C:\Users\Public\chrome_policy_templates\windows\admx\en-US C:\Windows\PolicyDefinitions\en-US
+      win_command: xcopy /y C:\Users\Public\chrome_policy_templates\windows\admx\en-US\* C:\Windows\PolicyDefinitions\en-US\
     - name: Install Google Chrome policy template (ja-JP locale)
       when: not "${var.chrome-policy-template-url}" == ""
-      win_command: xcopy /y C:\Users\Public\chrome_policy_templates\windows\admx\ja-JP C:\Windows\PolicyDefinitions\ja-JP
+      win_command: xcopy /y C:\Users\Public\chrome_policy_templates\windows\admx\ja-JP\* C:\Windows\PolicyDefinitions\ja-JP\
     - name: Download Edge installer
       when: not "${var.edge-installer-download-url}" == ""
       win_get_url:


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

Copying policy templates may fail with current playbook. We need to update command lines for xcopy.

# How to verify the fixed issue:

Prepare any verification environment.

## The steps to verify:

1. Cd to `doc/verify/windows-11-22H2` or any environment.
2. Run `make`.

## Expected result:

Environment is successfully prepared with no error around copying policy templates.