### PR TITLE
Don't reset m_gbTraceLog by constructor of URLRedirector

### DIFF
--- a/BHORedirector/URLRedirectCore.h
+++ b/BHORedirector/URLRedirectCore.h
@@ -277,7 +277,6 @@ public:
 		FILETIME FileTimeZero={0};
 		m_FileTime=FileTimeZero;
 		m_bURLOnly=FALSE;
-		m_gbTraceLog=FALSE;
 		m_bQuickRedirect = FALSE;
 		m_bUseNeutralSite =FALSE;
 		m_bTopURLOnly=FALSE;
@@ -291,7 +290,6 @@ public:
 	void Clear()
 	{
 		m_bURLOnly=FALSE;
-		m_gbTraceLog=FALSE;
 		m_bQuickRedirect = FALSE;
 		m_bUseNeutralSite =FALSE;
 		m_bTopURLOnly=FALSE;


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

Since m_gbTraceLog is a global variable, resetting it at the constructor of URLRedirector isn't appropriate. Because when an instance of URLRedirector created but it don't yet parse the configuration, trace log feature will be unexpectedly disabled at global scope.

# How to verify the fixed issue:

I'm not sure how to verify it.
At least this fix shouldn't break current behaviour.

## The steps to verify:

Ditto

## Expected result:

Ditto
