### PR TITLE
Fallback to self if default browser is not configured

### DIFF
--- a/webextensions/chrome/background.js
+++ b/webextensions/chrome/background.js
@@ -287,6 +287,14 @@ const ThinBridgeTalkClient = {
     }
     console.log(`* Result: [${matchedSectionNames.join(', ')}]`);
 
+    if (redirectCount == 0) {
+      if (config.DefaultBrowser == '' ||
+          String(config.DefaultBrowser).toLowerCase() == BROWSER.toLowerCase())
+        loadCount++;
+      else
+        redirectCount++;
+    }
+
     if (redirectCount > 0 || loadCount == 0) {
       console.log(`* Redirect to another browser`);
       this.redirect(url, tabId, closeTabCount > 0);

--- a/webextensions/chrome/background.js
+++ b/webextensions/chrome/background.js
@@ -288,11 +288,16 @@ const ThinBridgeTalkClient = {
     console.log(`* Result: [${matchedSectionNames.join(', ')}]`);
 
     if (redirectCount == 0) {
+      console.log(`* No redirection: fallback to default`);
       if (config.DefaultBrowser == '' ||
-          String(config.DefaultBrowser).toLowerCase() == BROWSER.toLowerCase())
+          String(config.DefaultBrowser).toLowerCase() == BROWSER.toLowerCase()) {
+        console.log(`* Continue to load as the default reaction`);
         loadCount++;
-      else
+      }
+      else {
+        console.log(`* Redirect to the default browser ${config.DefaultBrowser}`);
         redirectCount++;
+      }
     }
 
     if (redirectCount > 0 || loadCount == 0) {

--- a/webextensions/chrome/manifest.json
+++ b/webextensions/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 3,
 	"name": "ThinBridge",
-	"version": "2.0.1",
+	"version": "2.0.2",
 	"description": "ThinBridge for Chrome",
 	"permissions": [
 		"nativeMessaging",

--- a/webextensions/edge/background.js
+++ b/webextensions/edge/background.js
@@ -287,6 +287,14 @@ const ThinBridgeTalkClient = {
     }
     console.log(`* Result: [${matchedSectionNames.join(', ')}]`);
 
+    if (redirectCount == 0) {
+      if (config.DefaultBrowser == '' ||
+          String(config.DefaultBrowser).toLowerCase() == BROWSER.toLowerCase())
+        loadCount++;
+      else
+        redirectCount++;
+    }
+
     if (redirectCount > 0 || loadCount == 0) {
       console.log(`* Redirect to another browser`);
       this.redirect(url, tabId, closeTabCount > 0);

--- a/webextensions/edge/background.js
+++ b/webextensions/edge/background.js
@@ -288,11 +288,16 @@ const ThinBridgeTalkClient = {
     console.log(`* Result: [${matchedSectionNames.join(', ')}]`);
 
     if (redirectCount == 0) {
+      console.log(`* No redirection: fallback to default`);
       if (config.DefaultBrowser == '' ||
-          String(config.DefaultBrowser).toLowerCase() == BROWSER.toLowerCase())
+          String(config.DefaultBrowser).toLowerCase() == BROWSER.toLowerCase()) {
+        console.log(`* Continue to load as the default reaction`);
         loadCount++;
-      else
+      }
+      else {
+        console.log(`* Redirect to the default browser ${config.DefaultBrowser}`);
         redirectCount++;
+      }
     }
 
     if (redirectCount > 0 || loadCount == 0) {

--- a/webextensions/edge/manifest.json
+++ b/webextensions/edge/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 3,
 	"name": "__MSG_extName__",
-	"version": "2.0.1",
+	"version": "2.0.2",
 	"description": "__MSG_extDescription__",
 	"permissions": [
 		"nativeMessaging",

--- a/webextensions/firefox/background.js
+++ b/webextensions/firefox/background.js
@@ -287,6 +287,14 @@ const ThinBridgeTalkClient = {
     }
     console.log(`* Result: [${matchedSectionNames.join(', ')}]`);
 
+    if (redirectCount == 0) {
+      if (config.DefaultBrowser == '' ||
+          String(config.DefaultBrowser).toLowerCase() == BROWSER.toLowerCase())
+        loadCount++;
+      else
+        redirectCount++;
+    }
+
     if (redirectCount > 0 || loadCount == 0) {
       console.log(`* Redirect to another browser`);
       this.redirect(url, tabId, closeTabCount > 0);

--- a/webextensions/firefox/background.js
+++ b/webextensions/firefox/background.js
@@ -288,11 +288,16 @@ const ThinBridgeTalkClient = {
     console.log(`* Result: [${matchedSectionNames.join(', ')}]`);
 
     if (redirectCount == 0) {
+      console.log(`* No redirection: fallback to default`);
       if (config.DefaultBrowser == '' ||
-          String(config.DefaultBrowser).toLowerCase() == BROWSER.toLowerCase())
+          String(config.DefaultBrowser).toLowerCase() == BROWSER.toLowerCase()) {
+        console.log(`* Continue to load as the default reaction`);
         loadCount++;
-      else
+      }
+      else {
+        console.log(`* Redirect to the default browser ${config.DefaultBrowser}`);
         redirectCount++;
+      }
     }
 
     if (redirectCount > 0 || loadCount == 0) {

--- a/webextensions/firefox/manifest.json
+++ b/webextensions/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 2,
 	"name": "ThinBridge",
-	"version": "1.6.1",
+	"version": "1.6.2",
 	"description": "ThinBridge for Firefox",
 	"permissions": [
 		"nativeMessaging",


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

On old versions (Manifest V2), ThinBridge browser extension (Chrome, Edge, Firefox) loads the URL if there is no match AND the default browser is not specified.
However, currently (Manifest V3) the URL is redirected to the system default browser.
This PR fixes this incompatibility.

# How to verify the fixed issue:

Configure redirection rules and no default browser, and try loading URL which should not match any rule.

## The steps to verify:

1. Install ThinBridge (64bit version) from the installer.
2. Configure `C:\Program Files\ThinBridge\ThinBridgeBHO.ini` as following:
   ```
   [GLOBAL]
   @DISABLED
   @TOP_PAGE_ONLY
   @INTRANET_ZONE
   @TRUSTED_ZONE
   @UNTRUSTED_ZONE
   @RDP_APPMODE
   
   [Chrome]
   @BROWSER_PATH:
   @TOP_PAGE_ONLY
   @REDIRECT_PAGE_ACTION:0
   @CLOSE_TIMEOUT:1
   *
   -http://localhost*
   -https://localhost*
      
   [Default]
   @BROWSER_PATH:
   @TOP_PAGE_ONLY
   @REDIRECT_PAGE_ACTION:0
   @CLOSE_TIMEOUT:3
   ```
3. Build CRX for Edge. (`cd webextensions && make`)
4. Install the built CRX to Edge as a managed extension. See instructions (for BrowserSelector): https://gitlab.com/clear-code/browserselector#notes-for-manifest-v3
5. Add the ID of the built CRX to the file: `C:\Program Files\ThinBridge\ThinBridgeHost\edge.json`
6. Start Edge.
7. Try to load https://example.com/
8. Try to load https://localhost/

## Expected result:

* https://example.com/ is redirected to Chrome.
* https://localhost/ is loaded by Edge.

