### PR TITLE
ci: use v2 series of microsoft/setup-msbuild action

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -5,7 +5,7 @@ jobs:
     runs-on: [ windows-2019 ]
     steps:
       - uses: actions/checkout@v3
-      - uses: microsoft/setup-msbuild@v1.2
+      - uses: microsoft/setup-msbuild@v2
       - name: Compile x86
         run: msbuild /p:Platform=Win32 /p:Configuration=Release
       - name: Compile x64


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

As Node 16 actions were deprecated, so migrate it!

![image](https://github.com/ThinBridge/ThinBridge/assets/225841/92f0bc2e-e3d3-4ac3-a700-afe64f662c02)

It fixes the following warning:

```
  Node.js 16 actions are deprecated. Please update the following
  actions to use Node.js 20: actions/checkout@v3,
  actions/upload-artifact@v3. For more information see:
  https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

Already some actions were migrated to actions/checkout@v3 and actions/upload-artifact@v3 which use node 20, the only one not yet migrated is microsoft/setup-msbuild.

In v2, https://github.com/microsoft/setup-msbuild/releases/tag/v2, microsoft/setup-msbuild officially supports node 20. 

# How to verify the fixed issue:

Check action result page such as https://github.com/ThinBridge/ThinBridge/actions/runs/.....


## Expected result:

There is no warning about node 16.
