### PR TITLE
Don't delete query parameters from redirected URL

### DIFF
--- a/webextensions/chrome/background.js
+++ b/webextensions/chrome/background.js
@@ -235,15 +235,13 @@ const ThinBridgeTalkClient = {
     }
 
     if (!/^https?:/.test(url)) {
-      console.log(`* Ignore non-HTTP/HTTPS URL`);
+      console.log(`* Ignore non-HTTP/HTTPS URL ${url}`);
       return false;
     }
 
-    if (config.IgnoreQueryString) {
-      url = url.replace(/\?.*/, '');
-    }
+    const urlToMatch = config.IgnoreQueryString ? url.replace(/\?.*/, '') : url;
 
-    console.log(`* Lookup sections for ${url}`);
+    console.log(`* Lookup sections for ${urlToMatch}`);
 
     let loadCount     = 0;
     let redirectCount = 0;
@@ -252,7 +250,7 @@ const ThinBridgeTalkClient = {
     sectionsLoop:
     for (const section of config.Sections) {
       console.log(`handleURLAndBlock: check for section ${section.Name} (${JSON.stringify(section)})`);
-      if (!this.match(section, url, config.NamedSections)) {
+      if (!this.match(section, urlToMatch, config.NamedSections)) {
         console.log(` => unmatched`);
         continue;
       }

--- a/webextensions/edge/background.js
+++ b/webextensions/edge/background.js
@@ -235,15 +235,13 @@ const ThinBridgeTalkClient = {
     }
 
     if (!/^https?:/.test(url)) {
-      console.log(`* Ignore non-HTTP/HTTPS URL`);
+      console.log(`* Ignore non-HTTP/HTTPS URL ${url}`);
       return false;
     }
 
-    if (config.IgnoreQueryString) {
-      url = url.replace(/\?.*/, '');
-    }
+    const urlToMatch = config.IgnoreQueryString ? url.replace(/\?.*/, '') : url;
 
-    console.log(`* Lookup sections for ${url}`);
+    console.log(`* Lookup sections for ${urlToMatch}`);
 
     let loadCount     = 0;
     let redirectCount = 0;
@@ -252,7 +250,7 @@ const ThinBridgeTalkClient = {
     sectionsLoop:
     for (const section of config.Sections) {
       console.log(`handleURLAndBlock: check for section ${section.Name} (${JSON.stringify(section)})`);
-      if (!this.match(section, url, config.NamedSections)) {
+      if (!this.match(section, urlToMatch, config.NamedSections)) {
         console.log(` => unmatched`);
         continue;
       }

--- a/webextensions/firefox/background.js
+++ b/webextensions/firefox/background.js
@@ -221,15 +221,13 @@ const ThinBridgeTalkClient = {
     }
 
     if (!/^https?:/.test(url)) {
-      console.log(`* Ignore non-HTTP/HTTPS URL`);
+      console.log(`* Ignore non-HTTP/HTTPS URL ${url}`);
       return false;
     }
 
-    if (config.IgnoreQueryString) {
-      url = url.replace(/\?.*/, '');
-    }
+    const urlToMatch = config.IgnoreQueryString ? url.replace(/\?.*/, '') : url;
 
-    console.log(`* Lookup sections for ${url}`);
+    console.log(`* Lookup sections for ${urlToMatch}`);
 
     let loadCount     = 0;
     let redirectCount = 0;
@@ -238,7 +236,7 @@ const ThinBridgeTalkClient = {
     sectionsLoop:
     for (const section of config.Sections) {
       console.log(`handleURLAndBlock: check for section ${section.Name} (${JSON.stringify(section)})`);
-      if (!this.match(section, url, config.NamedSections)) {
+      if (!this.match(section, urlToMatch, config.NamedSections)) {
         console.log(` => unmatched`);
         continue;
       }


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

We need to keep query parameters in URL while redirection. It was unexpectedly lost at Manifest V3 versions.

Another PR https://github.com/ThinBridge/ThinBridge/pull/57 adds regression test to the pre-release verification.

# How to verify the fixed issue:

See tests added by https://github.com/ThinBridge/ThinBridge/pull/57

## The steps to verify:

See tests added by https://github.com/ThinBridge/ThinBridge/pull/57

## Expected result:

All regression tests passed.
