### PR TITLE
Fix a typo

### DIFF
--- a/webextensions/chrome/background.js
+++ b/webextensions/chrome/background.js
@@ -261,7 +261,7 @@ const ThinBridgeTalkClient = {
       if (config.CloseEmptyTab && isClosableTab)
         closeTabCount++;
 
-      console.log(` => matched, action = ${config.Action}`);
+      console.log(` => matched, action = ${section.Action}`);
       if (section.Action) {
         switch(section.Action.toLowerCase()) {
           case 'redirect':

--- a/webextensions/edge/background.js
+++ b/webextensions/edge/background.js
@@ -261,7 +261,7 @@ const ThinBridgeTalkClient = {
       if (config.CloseEmptyTab && isClosableTab)
         closeTabCount++;
 
-      console.log(` => matched, action = ${config.Action}`);
+      console.log(` => matched, action = ${section.Action}`);
       if (section.Action) {
         switch(section.Action.toLowerCase()) {
           case 'redirect':

--- a/webextensions/firefox/background.js
+++ b/webextensions/firefox/background.js
@@ -247,7 +247,7 @@ const ThinBridgeTalkClient = {
       if (config.CloseEmptyTab && isClosableTab)
         closeTabCount++;
 
-      console.log(` => matched, action = ${config.Action}`);
+      console.log(` => matched, action = ${section.Action}`);
       if (section.Action) {
         switch(section.Action.toLowerCase()) {
           case 'redirect':


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A.

# What this PR does / why we need it:

A wrong parent object is specified to show a property in a log message. `config.Action` doesn't exist even in our internal customized version of ThinBridgeTalk. It should be `section.Action`


# How to verify the fixed issue:

N/A

## The steps to verify:

N/A

## Expected result:

N/A
