### PR TITLE
Improve compatibility with ManifestV2 version of this add-on

### DIFF
--- a/webextensions/firefox/background.js
+++ b/webextensions/firefox/background.js
@@ -232,10 +232,15 @@ const ThinBridgeTalkClient = {
     let loadCount     = 0;
     let redirectCount = 0;
     let closeTabCount = 0;
+    let isActionMode  = false;
     const matchedSectionNames = [];
     sectionsLoop:
     for (const section of config.Sections) {
       console.log(`handleURLAndBlock: check for section ${section.Name} (${JSON.stringify(section)})`);
+
+      if (section.Action)
+        isActionMode = true;
+
       if (!this.match(section, urlToMatch, config.NamedSections)) {
         console.log(` => unmatched`);
         continue;
@@ -249,6 +254,7 @@ const ThinBridgeTalkClient = {
 
       console.log(` => matched, action = ${section.Action}`);
       if (section.Action) {
+        // a.k.a "full mode" in IE View WE
         switch(section.Action.toLowerCase()) {
           case 'redirect':
             redirectCount++;
@@ -263,6 +269,7 @@ const ThinBridgeTalkClient = {
           break sectionsLoop;
       }
       else {
+        // Compatible mode with ManifestV2 version of this add-on
         switch (this.getBrowserName(section)) {
           case DMZ_SECTION:
             console.log(` => action not defined, default action for CUSTOM18: load`);
@@ -285,25 +292,44 @@ const ThinBridgeTalkClient = {
     }
     console.log(`* Result: [${matchedSectionNames.join(', ')}]`);
 
-    if (redirectCount == 0) {
-      console.log(`* No redirection: fallback to default`);
-      if (config.DefaultBrowser == '' ||
-          String(config.DefaultBrowser).toLowerCase() == BROWSER.toLowerCase()) {
-        console.log(`* Continue to load as the default reaction`);
-        loadCount++;
+    if (isActionMode) {
+      // a.k.a "full mode" in IE View WE
+      console.log(`* Dispatch as action mode`);
+      if (redirectCount > 0 || loadCount == 0) {
+        console.log(`* Redirect to another browser`);
+        this.redirect(url, tabId, closeTabCount > 0);
       }
-      else {
-        console.log(`* Redirect to the default browser ${config.DefaultBrowser}`);
-        redirectCount++;
-      }
+      console.log(`* Continue to load: ${loadCount > 0}`);
+      return loadCount == 0;
     }
+    else {
+      // Compatible mode with ManifestV2 version of this add-on
+      console.log(`* Dispatch as compatible mode`);
 
-    if (redirectCount > 0 || loadCount == 0) {
-      console.log(`* Redirect to another browser`);
-      this.redirect(url, tabId, closeTabCount > 0);
+      if (loadCount > 0) {
+        console.log(`* Continue to load`);
+        return false;
+      }
+
+      if (redirectCount > 0) {
+        console.log(`* Redirect to another browser`);
+        this.redirect(url, tabId, closeTabCount > 0);
+        return true;
+      }
+
+      if (config.DefaultBrowser) {
+        console.log(`* Use DefaultBrowser: ${config.DefaultBrowser}`);
+        if (String(config.DefaultBrowser).toLowerCase() == BROWSER.toLowerCase()) {
+          return false;
+        } else {
+          this.redirect(url, tabId, closeTabCount > 0);
+          return true;
+        }
+      } else {
+        console.log(`* DefaultBrowser is blank`);
+        return false;
+      }
     }
-    console.log(`* Continue to load: ${loadCount > 0}`);
-    return loadCount == 0;
   },
 
   /* Handle startup tabs preceding to onBeforeRequest */


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

ThinBridge browser add-ons v2.1.0 breaks compatibility with v1.4.0, especially behaviour of default browser is broken.
This patch tries to fix this issue.
To avoid confusion, this patch separates code blocks between `action mode` (a.k.a `full mode` in IE View WE) and `compatible mode`. Because both modes have conflict concepts with others, we shouldn't mix them in one specification.

# How to verify the fixed issue:

Verify all steps in [PreReleaseVerification.md](doc/verify/PreReleaseVerification.md).

## The steps to verify:

See [PreReleaseVerification.md](doc/verify/PreReleaseVerification.md).

## Expected result:

See [PreReleaseVerification.md](doc/verify/PreReleaseVerification.md).
