### PR TITLE
Inconsistent expected result based on on Edge extension 1.4.0

### DIFF
--- a/doc/verify/PreReleaseVerification.md
+++ b/doc/verify/PreReleaseVerification.md
@@ -772,7 +772,7 @@
         * ThinBridgeによるリダイレクトが発生しない。
    9. アドレスバーに https://pgroonga.github.io/ を入力し、Enterする。
       * 期待される結果：
-        * Edgeのタブでの読み込みが中断されるか、EdgeのタブがThinBridgeにより閉じられる。
+        * 初回試行時には、EdgeのタブがThinBridgeにより閉じられる。2回目以降の試行時には、Edgeのタブは閉じられずにタブでの読み込みが中断される。
         * ThinBridgeによるリダイレクトが発生し、「Citrixがインストールされていないか、設定されていないため起動できません。」というメッセージが表示される。
    10. Edge（IEモード）→Edge（IEモード）の検証のため、`edge://settings/defaultBrowser` を開き、IEモードの対象URLを以下の通り設定する。
        * 追加： https://pgroonga.github.io/

--- a/doc/verify/PreReleaseVerification.md
+++ b/doc/verify/PreReleaseVerification.md
@@ -772,7 +772,7 @@
         * ThinBridgeによるリダイレクトが発生しない。
    9. アドレスバーに https://pgroonga.github.io/ を入力し、Enterする。
       * 期待される結果：
-        * Edgeのタブでの読み込みが中断される。
+        * Edgeのタブでの読み込みが中断されるか、EdgeのタブがThinBridgeにより閉じられる。
         * ThinBridgeによるリダイレクトが発生し、「Citrixがインストールされていないか、設定されていないため起動できません。」というメッセージが表示される。
    10. Edge（IEモード）→Edge（IEモード）の検証のため、`edge://settings/defaultBrowser` を開き、IEモードの対象URLを以下の通り設定する。
        * 追加： https://pgroonga.github.io/


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

Current expected result is based on results with Edge extension 1.4.0.
On the environment I got inconsistent result on a case.
This PR makes the inconsistency more clear.

# How to verify the fixed issue:

See the modified section.

## The steps to verify:

1. See doc/PreReleaseVerification.md
2. See 4-ⅸ under the section `EdgeのIEモード境界をまたぐページ遷移におけるDefault設定の動作`.

## Expected result:

There is an inconsistent result `初回試行時には、EdgeのタブがThinBridgeにより閉じられる。2回目以降の試行時には、Edgeのタブは閉じられずにタブでの読み込みが中断される。`