### PR TITLE
Bump Edge and Chrome extensions version to 2.1.1

### DIFF
--- a/webextensions/chrome/manifest.json
+++ b/webextensions/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 3,
 	"name": "ThinBridge",
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"description": "ThinBridge for Chrome",
 	"permissions": [
 		"nativeMessaging",

--- a/webextensions/edge/manifest.json
+++ b/webextensions/edge/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 3,
 	"name": "__MSG_extName__",
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"description": "__MSG_extDescription__",
 	"permissions": [
 		"nativeMessaging",


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

This bumps version of Edge and Chrome extensions to 2.1.1.


# How to verify the fixed issue:

Install extensions and confirm their versions are 2.1.1.

## The steps to verify:

1. With the developer mode, load extensions to Edge and Chrome.
2. See details of installed extensions.

## Expected result:

They have 2.1.1 version.