### PR TITLE
Add unit tests for v1.4.0

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-on: [push pull_request]
+on: [ push, pull_request ]
 name: Test WebExtensions
 jobs:
   test:
@@ -7,4 +7,4 @@ jobs:
       - uses: actions/checkout@v3
       - name: Testing WebExtensions
         run: |
-          make -C webextensions test
+          make -C webextension test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,10 @@
+on: [push pull_request]
+name: Test WebExtensions
+jobs:
+  test:
+    runs-on: [ ubuntu-latest ]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Testing WebExtensions
+        run: |
+          make -C webextensions test

--- a/webextension/Makefile
+++ b/webextension/Makefile
@@ -1,9 +1,9 @@
-.PHONY: clean packages install_dependency lint format install_hook
+.PHONY: clean install_dependency
 
 NPM_MOD_DIR := $(CURDIR)/node_modules
 NPM_BIN_DIR := $(NPM_MOD_DIR)/.bin
 
-all: packages
+all: test
 
 testee:
 	mkdir $@
@@ -20,23 +20,7 @@ test-verbose: install_dependency testee/edge.js
 	npx mocha test
 
 clean:
-	rm -f *.zip
-	rm -f *.xpi
-
-packages: clean lint
-	cd chrome && make && make dev && mv *.zip ../
-	cd edge && make && make dev && mv *.zip ../
-	cd firefox && make && mv *.xpi ../
+	rm -rf testee
 
 install_dependency:
-	[ -e "$(NPM_BIN_DIR)/eslint" -a -e "$(NPM_BIN_DIR)/jsonlint-cli" ] || npm install --save-dev
-
-lint: install_dependency
-	"$(NPM_BIN_DIR)/eslint" . --ext=.js --report-unused-disable-directives
-	find . -type d -name node_modules -prune -o -type f -name '*.json' -print | xargs "$(NPM_BIN_DIR)/jsonlint-cli"
-
-format: install_dependency
-	"$(NPM_BIN_DIR)/eslint" . --ext=.js --report-unused-disable-directives --fix
-
-install_hook:
-	echo '#!/bin/sh\nmake lint' > "$(CURDIR)/../.git/hooks/pre-commit" && chmod +x "$(CURDIR)/../.git/hooks/pre-commit"
+	npm install --save-dev

--- a/webextension/Makefile
+++ b/webextension/Makefile
@@ -1,0 +1,42 @@
+.PHONY: clean packages install_dependency lint format install_hook
+
+NPM_MOD_DIR := $(CURDIR)/node_modules
+NPM_BIN_DIR := $(NPM_MOD_DIR)/.bin
+
+all: packages
+
+testee:
+	mkdir $@
+
+testee/edge.js: edge/background.js testee
+	sed -e "s/ThinBridgeTalkClient.init();/exports.client = ThinBridgeTalkClient/g" -e "s/ResourceCap.init();//g" edge/background.js > $@
+
+unittest: install_dependency testee/edge.js
+	npx mocha --require mocha-suppress-logs test
+
+test: unittest
+
+test-verbose: install_dependency testee/edge.js
+	npx mocha test
+
+clean:
+	rm -f *.zip
+	rm -f *.xpi
+
+packages: clean lint
+	cd chrome && make && make dev && mv *.zip ../
+	cd edge && make && make dev && mv *.zip ../
+	cd firefox && make && mv *.xpi ../
+
+install_dependency:
+	[ -e "$(NPM_BIN_DIR)/eslint" -a -e "$(NPM_BIN_DIR)/jsonlint-cli" ] || npm install --save-dev
+
+lint: install_dependency
+	"$(NPM_BIN_DIR)/eslint" . --ext=.js --report-unused-disable-directives
+	find . -type d -name node_modules -prune -o -type f -name '*.json' -print | xargs "$(NPM_BIN_DIR)/jsonlint-cli"
+
+format: install_dependency
+	"$(NPM_BIN_DIR)/eslint" . --ext=.js --report-unused-disable-directives --fix
+
+install_hook:
+	echo '#!/bin/sh\nmake lint' > "$(CURDIR)/../.git/hooks/pre-commit" && chmod +x "$(CURDIR)/../.git/hooks/pre-commit"

--- a/webextension/package.json
+++ b/webextension/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "thinbridge",
+  "version": "0.0.0",
+  "engines": {
+    "node": ">=13.2"
+  },
+  "devDependencies": {
+    "mocha": ">=10.4.0",
+    "mocha-suppress-logs": "^0.5.1",
+    "sinon": "^14.0.0"
+  }
+}

--- a/webextension/test/chrome-stub.js
+++ b/webextension/test/chrome-stub.js
@@ -1,0 +1,36 @@
+global.chrome = {
+    alarms: {
+	create: function() {
+	},
+	onAlarm: {
+	    addListener: function() {
+	    }
+	},
+    },
+    runtime: {
+	sendNativeMessage: function() {
+	},
+    },
+    tabs: {
+	onCreated: {
+	    addListener: function() {
+	    }
+	},
+	onUpdated: {
+	    addListener: function() {
+	    }
+	},
+    },
+    webRequest: {
+	onBeforeRequest: {
+	    addListener: function() {
+	    },
+	},
+    },
+    webNavigation: {
+	onCommitted: {
+	    addListener: function() {
+	    }
+	},
+    },
+};

--- a/webextension/test/test-edge.js
+++ b/webextension/test/test-edge.js
@@ -100,13 +100,6 @@ describe('Microsoft Edge Add-on', () => {
       assert.equal(shouldBlock, true);
     });
 
-    it('do not close tab', () => {
-      const url = "https://www.google.com/";
-      const conf = config([chromeSection], { CloseEmptyTab: false })
-      const shouldBlock = thinbridge.isRedirectURL(conf, url);
-      assert.equal(shouldBlock, true);
-    });
-
     it('custom18 should be loaded', () => {
       const url = "https://www.example.com/";
       const conf = config([custom18Section])

--- a/webextension/test/test-edge.js
+++ b/webextension/test/test-edge.js
@@ -160,13 +160,6 @@ describe('Microsoft Edge Add-on', () => {
       assert.equal(shouldBlock, true);
     });
 
-    it('query is preserved', () => {
-      const conf = config([citrixSection]);
-      const url = "https://www.google.com/search?q=foobar";
-      const shouldBlock = thinbridge.isRedirectURL(conf, url);
-      assert.equal(shouldBlock, true);
-    });
-
     it('ignore query', () => {
       const url = "https://www.google.com/search?q=hoge";
       const conf = config([queryTestSection], { DefaultBrowser: "" })

--- a/webextension/test/test-edge.js
+++ b/webextension/test/test-edge.js
@@ -1,0 +1,184 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const chromestub = require('./chrome-stub.js')
+const edge = require('../testee/edge.js');
+
+describe('Microsoft Edge Add-on', () => {
+  const isClosableTab = true;
+  const tabId = 123;
+  const shouldCloseTab = true;
+  const baseConfig = {
+    CloseEmptyTab: 1,
+    DefaultBrowser: "Chrome",
+    IgnoreQueryString: 1,
+    OnlyMainFrame : 1,
+    Sections: [],
+  }
+  const citrixSection = {
+    "Name": "citrix",
+    "Patterns": ["https://www.google.com/*"],
+    "Excludes": [],
+  };
+  const edgeSection = { // should not redirect since it's me
+    "Name": "edge",
+    "Patterns": ["https://www.microsoft.com/*"],
+    "Excludes": [],
+  };
+  const chromeSection = {
+    "Name": "chrome",
+    "Patterns": ["*://*"],
+    "Excludes": [],
+  };
+  const custom18Section = {  // a.k.a DMZ section, should not redirect
+    "Name": "custom18",
+    "Patterns": ["https://www.example.com/*"],
+    "Excludes": [],
+  };
+  const queryTestSection = {
+    "Name": "firefox",
+    "Patterns": ["https://www.google.com/search"],
+    "Excludes": [],
+  };
+
+  function config(sections = [], additionals = {}) {
+    const config = {...baseConfig, ...additionals};
+    config.Sections = [...config.Sections, ...sections];
+    config.NamedSections = Object.fromEntries(config.Sections.map(section => [section.Name, section]));
+    return config;
+  }
+
+
+  const thinbridge = edge.client;
+  let thinbridge_mock;
+
+  beforeEach(() => {
+    thinbridge_mock = sinon.mock(thinbridge);
+  });
+
+  afterEach(() => {
+    thinbridge_mock.restore();
+  });
+
+
+  describe('isRedirectURL', () => {
+
+    it('no match should be redirected', () => {
+      const url = "https://www.google.com/";
+      const conf = config();
+      const shouldBlock = thinbridge.isRedirectURL(conf, url);
+      assert.equal(shouldBlock, true);
+    });
+
+    it('no match and no default should be loaded', () => {
+      const url = "https://www.google.com/";
+      const conf = config([], { DefaultBrowser: "" });
+      const shouldBlock = thinbridge.isRedirectURL(conf, url);
+      assert.equal(shouldBlock, false);
+    });
+
+    it('match redirect', () => {
+      const url = "https://www.google.com/";
+      const conf = config([chromeSection])
+      const shouldBlock = thinbridge.isRedirectURL(conf, url);
+      assert.equal(shouldBlock, true);
+    });
+
+    it('multiple patterns', () => {
+      const url = "https://www.example.com/";
+      const conf = config(
+        [{
+          "Name": "chrome",
+          "Patterns": [
+            "https://www.google.com/*",
+            "https://www.microsoft.com/*",
+            "https://www.example.com/*",
+          ],
+          "Excludes": [],
+        }]
+      )
+      const shouldBlock = thinbridge.isRedirectURL(conf, url);
+      assert.equal(shouldBlock, true);
+    });
+
+    it('do not close tab', () => {
+      const url = "https://www.google.com/";
+      const conf = config([chromeSection], { CloseEmptyTab: false })
+      const shouldBlock = thinbridge.isRedirectURL(conf, url);
+      assert.equal(shouldBlock, true);
+    });
+
+    it('custom18 should be loaded', () => {
+      const url = "https://www.example.com/";
+      const conf = config([custom18Section])
+      const shouldBlock = thinbridge.isRedirectURL(conf, url);
+      assert.equal(shouldBlock, false);
+    });
+
+    it('custom18 should be prior than others', () => {
+      const url = "https://www.example.com/";
+      const conf = config([chromeSection, custom18Section])
+      const shouldBlock = thinbridge.isRedirectURL(conf, url);
+      assert.equal(shouldBlock, false);
+    });
+
+    it('edge section should be loaded', () => {
+      const url = "https://www.microsoft.com/";
+      const conf = config([edgeSection])
+      const shouldBlock = thinbridge.isRedirectURL(conf, url);
+      assert.equal(shouldBlock, false);
+    });
+
+    it('edge section should be prior than others', () => {
+      const url = "https://www.microsoft.com/";
+      const conf = config([chromeSection, edgeSection])
+      const shouldBlock = thinbridge.isRedirectURL(conf, url);
+      assert.equal(shouldBlock, false);
+    });
+
+    it('match exclude pattern', () => {
+      const url = "https://www.example.com/index.html";
+      const conf = config([custom18Section])
+      conf.Sections[0].Excludes = [url]
+      const shouldBlock = thinbridge.isRedirectURL(conf, url);
+      assert.equal(shouldBlock, true);
+    });
+
+    it('match multiple exclude pattern', () => {
+      const url = "https://www.example.com/";
+      const conf = config(
+        [{
+          "Name": "custom18",
+          "Patterns": ["*"],
+          "Excludes": [
+            "https://www.google.com/*",
+            "https://www.microsoft.com/*",
+            "https://www.example.com/*",
+          ],
+        }]
+      );
+      const shouldBlock = thinbridge.isRedirectURL(conf, url);
+      assert.equal(shouldBlock, true);
+    });
+
+    it('query is preserved', () => {
+      const conf = config([citrixSection]);
+      const url = "https://www.google.com/search?q=foobar";
+      const shouldBlock = thinbridge.isRedirectURL(conf, url);
+      assert.equal(shouldBlock, true);
+    });
+
+    it('ignore query', () => {
+      const url = "https://www.google.com/search?q=hoge";
+      const conf = config([queryTestSection], { DefaultBrowser: "" })
+      const shouldBlock = thinbridge.isRedirectURL(conf, url);
+      assert.equal(shouldBlock, true);
+    });
+
+    it('match with query', () => {
+      const url = "https://www.google.com/search?q=hoge";
+      const conf = config([queryTestSection], { DefaultBrowser: "", IgnoreQueryString: 0 })
+      const shouldBlock = thinbridge.isRedirectURL(conf, url);
+      assert.equal(shouldBlock, false);
+    });
+  });
+});


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

Too verify correctness of tests for MV3, we should run same tests against v1.4.0 which is MV2 version of add-ons.

# How to verify the fixed issue:

All tests pass

## The steps to verify:

Run tet

## Expected result:

All tests pass
