### PR TITLE
Fix switch-case indent setting for Emacs

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,2 +1,3 @@
 ((js-mode .  ((indent-tabs-mode . nil)
-              (js-indent-level  . 2))))
+              (js-indent-level  . 2)
+              (js-switch-indent-offset . 2))))


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

I want to add an indentation setting for Emacs about switch-case statement.

# How to verify the fixed issue:

N/A

## The steps to verify:

N/A

## Expected result:

N/A