### PR TITLE
Close redirected tab for default case

### DIFF
--- a/doc/verify/PreReleaseVerification.md
+++ b/doc/verify/PreReleaseVerification.md
@@ -709,7 +709,7 @@
         * ThinBridgeによるリダイレクトが発生しない。
    3. `Mroonga` のリンクをクリックする。
       * 期待される結果：
-        * タブの読み込みが中断される。
+        * タブがページ遷移しない。
         * ThinBridgeによるリダイレクトが発生し、 https://mroonga.org/ がIEで開かれるか、IEの起動を試みている旨を示すダイアログが表示される。
    4. Edge（通常モード）→Edge（IEモード）の検証のため、`edge://settings/defaultBrowser` を開き、IEモードの対象URLを以下の通り設定する。
       * 追加： https://mroonga.org/
@@ -719,7 +719,7 @@
         * ThinBridgeによるリダイレクトが発生しない。
    6. `Mroonga` のリンクをクリックする。
       * 期待される結果：
-        * タブがIEモードに切り替わらず、読み込みが中断される。
+        * タブがIEモードに切り替わらず、ページ遷移しない。
         * ThinBridgeによるリダイレクトが発生し、 https://mroonga.org/ がIEで開かれるか、IEの起動を試みている旨を示すダイアログが表示される。
    7. Edge（IEモード）→Edge（通常モード）の検証のため、`edge://settings/defaultBrowser` を開き、IEモードの対象URLを以下の通り設定する。
       * 削除： https://mroonga.org/
@@ -730,7 +730,7 @@
         * ThinBridgeによるリダイレクトが発生しない。
    9. アドレスバーに https://mroonga.org/ を入力し、Enterする。
       * 期待される結果：
-        * 初回試行時には、EdgeのタブがThinBridgeにより閉じられる。2回目以降の試行時には、Edgeのタブは閉じられずにタブでの読み込みが中断される。
+        * Edgeのタブがページ遷移しない。また、試行回によってはタブがThinBridgeによって閉じられる。
         * ThinBridgeによるリダイレクトが発生し、 https://mroonga.org/ がIEで開かれるか、IEの起動を試みている旨を示すダイアログが表示される。
    10. Edge（IEモード）→Edge（IEモード）の検証のため、`edge://settings/defaultBrowser` を開き、IEモードの対象URLを以下の通り設定する。
        * 追加： https://mroonga.org/
@@ -740,7 +740,7 @@
          * ThinBridgeによるリダイレクトが発生しない。
    12. `Mroonga` のリンクをクリックする。
        * 期待される結果：
-          * Edgeのタブでの読み込みが中断される。
+          * Edgeのタブがページ遷移しない。
           * ThinBridgeによるリダイレクトが発生し、 https://mroonga.org/ がIEで開かれるか、IEの起動を試みている旨を示すダイアログが表示される。
 4. 共用URL（CUSTOM18）に該当するURLの動作の検証：
    1. Edge（通常モード）→Edge（通常モード）の検証のため、`edge://settings/defaultBrowser` を開き、IEモードの対象URLを以下の通り設定する。
@@ -793,7 +793,7 @@
         * ThinBridgeによるリダイレクトが発生しない。
    3. `PGroonga` のリンクをクリックする。
       * 期待される結果：
-        * Edgeのタブでの読み込みが中断される。
+        * Edgeのタブがページ遷移しない。
         * ThinBridgeによるリダイレクトが発生し、「Citrixがインストールされていないか、設定されていないため起動できません。」というメッセージが表示される。
    4. Edge（通常モード）→Edge（IEモード）の検証のため、`edge://settings/defaultBrowser` を開き、IEモードの対象URLを以下の通り設定する。
       * 追加： https://pgroonga.github.io/
@@ -803,7 +803,7 @@
         * ThinBridgeによるリダイレクトが発生しない。
    6. `PGroonga` のリンクをクリックする。
       * 期待される結果：
-        * Edgeのタブでの読み込みが中断される。
+        * Edgeのタブがページ遷移しない。
         * ThinBridgeによるリダイレクトが発生し、「Citrixがインストールされていないか、設定されていないため起動できません。」というメッセージが表示される。
    7. Edge（IEモード）→Edge（通常モード）の検証のため、`edge://settings/defaultBrowser` を開き、IEモードの対象URLを以下の通り設定する。
       * 削除： https://pgroonga.github.io/
@@ -814,7 +814,7 @@
         * ThinBridgeによるリダイレクトが発生しない。
    9. アドレスバーに https://pgroonga.github.io/ を入力し、Enterする。
       * 期待される結果：
-        * 初回試行時には、EdgeのタブがThinBridgeにより閉じられる。2回目以降の試行時には、Edgeのタブは閉じられずにタブでの読み込みが中断される。
+        * Edgeのタブがページ遷移しない。また、試行回によってはタブがThinBridgeによって閉じられる。
         * ThinBridgeによるリダイレクトが発生し、「Citrixがインストールされていないか、設定されていないため起動できません。」というメッセージが表示される。
    10. Edge（IEモード）→Edge（IEモード）の検証のため、`edge://settings/defaultBrowser` を開き、IEモードの対象URLを以下の通り設定する。
        * 追加： https://pgroonga.github.io/
@@ -824,7 +824,7 @@
          * ThinBridgeによるリダイレクトが発生しない。
    12. `PGroonga` のリンクをクリックする。
        * 期待される結果：
-         * Edgeのタブでの読み込みが中断される。
+         * Edgeのタブがページ遷移しない。
          * ThinBridgeによるリダイレクトが発生し、「Citrixがインストールされていないか、設定されていないため起動できません。」というメッセージが表示される。
 6. Edgeを終了する。
 
@@ -1027,7 +1027,7 @@
         * ThinBridgeによるリダイレクトが発生しない。
    3. `Mroonga` のリンクをクリックする。
       * 期待される結果：
-        * Edgeのタブでの読み込みが中断される。
+        * Edgeのタブがページ遷移しない。
         * ThinBridgeによるリダイレクトが発生し、 https://mroonga.org/ がIEで開かれるか、IEの起動を試みている旨を示すダイアログが表示される。
    4. Edge（通常モード）→Edge（IEモード）の検証のため、`edge://settings/defaultBrowser` を開き、IEモードの対象URLを以下の通り設定する。
       * 追加： https://mroonga.org/
@@ -1037,7 +1037,7 @@
         * ThinBridgeによるリダイレクトが発生しない。
    6. `Mroonga` のリンクをクリックする。
       * 期待される結果：
-        * タブがIEモードに切り替わらず、読み込みが中断される。
+        * タブがIEモードに切り替わらず、ページ遷移しない。
         * ThinBridgeによるリダイレクトが発生し、 https://mroonga.org/ がIEで開かれるか、IEの起動を試みている旨を示すダイアログが表示される。
    7. Edge（IEモード）→Edge（通常モード）の検証のため、`edge://settings/defaultBrowser` を開き、IEモードの対象URLを以下の通り設定する。
       * 削除： https://mroonga.org/
@@ -1048,7 +1048,7 @@
         * ThinBridgeによるリダイレクトが発生しない。
    9. アドレスバーに https://mroonga.org/ を入力し、Enterする。
       * 期待される結果：
-        * 初回試行時には、EdgeのタブがThinBridgeにより閉じられる。2回目以降の試行時には、Edgeのタブは閉じられずにタブでの読み込みが中断される。
+        * Edgeのタブがページ遷移しない。また、試行回によってはタブがThinBridgeによって閉じられる。
         * ThinBridgeによるリダイレクトが発生し、 https://mroonga.org/ がIEで開かれるか、IEの起動を試みている旨を示すダイアログが表示される。
    10. Edge（IEモード）→Edge（IEモード）の検証のため、`edge://settings/defaultBrowser` を開き、IEモードの対象URLを以下の通り設定する。
        * 追加： https://mroonga.org/
@@ -1058,7 +1058,7 @@
          * ThinBridgeによるリダイレクトが発生しない。
    12. `Mroonga` のリンクをクリックする。
        * 期待される結果：
-          * Edgeのタブでの読み込みが中断される。
+          * Edgeのタブがページ遷移しない。
           * ThinBridgeによるリダイレクトが発生し、 https://mroonga.org/ がIEで開かれるか、IEの起動を試みている旨を示すダイアログが表示される。
 4. 共用URL（CUSTOM18）に該当するURLの動作の検証：
    1. Edge（通常モード）→Edge（通常モード）の検証のため、`edge://settings/defaultBrowser` を開き、IEモードの対象URLを以下の通り設定する。

--- a/webextensions/chrome/background.js
+++ b/webextensions/chrome/background.js
@@ -243,9 +243,10 @@ const ThinBridgeTalkClient = {
 
     console.log(`* Lookup sections for ${urlToMatch}`);
 
+    const closeTabOnRedirect = config.CloseEmptyTab && isClosableTab;
+
     let loadCount     = 0;
     let redirectCount = 0;
-    let closeTabCount = 0;
     let isActionMode  = false;
     const matchedSectionNames = [];
     sectionsLoop:
@@ -262,9 +263,6 @@ const ThinBridgeTalkClient = {
 
       const sectionName = (section.Name || '').toLowerCase();
       matchedSectionNames.push(sectionName);
-
-      if (config.CloseEmptyTab && isClosableTab)
-        closeTabCount++;
 
       console.log(` => matched, action = ${section.Action}`);
       if (section.Action) {
@@ -311,7 +309,7 @@ const ThinBridgeTalkClient = {
       console.log(`* Dispatch as action mode`);
       if (redirectCount > 0 || loadCount == 0) {
         console.log(`* Redirect to another browser`);
-        this.redirect(url, tabId, closeTabCount > 0);
+        this.redirect(url, tabId, closeTabOnRedirect);
       }
       console.log(`* Continue to load: ${loadCount > 0}`);
       return loadCount == 0;
@@ -327,7 +325,7 @@ const ThinBridgeTalkClient = {
 
       if (redirectCount > 0) {
         console.log(`* Redirect to another browser`);
-        this.redirect(url, tabId, closeTabCount > 0);
+        this.redirect(url, tabId, closeTabOnRedirect);
         return true;
       }
 
@@ -336,7 +334,7 @@ const ThinBridgeTalkClient = {
         if (String(config.DefaultBrowser).toLowerCase() == BROWSER.toLowerCase()) {
           return false;
         } else {
-          this.redirect(url, tabId, closeTabCount > 0);
+          this.redirect(url, tabId, closeTabOnRedirect);
           return true;
         }
       } else {

--- a/webextensions/edge/background.js
+++ b/webextensions/edge/background.js
@@ -243,9 +243,10 @@ const ThinBridgeTalkClient = {
 
     console.log(`* Lookup sections for ${urlToMatch}`);
 
+    const closeTabOnRedirect = config.CloseEmptyTab && isClosableTab;
+
     let loadCount     = 0;
     let redirectCount = 0;
-    let closeTabCount = 0;
     let isActionMode  = false;
     const matchedSectionNames = [];
     sectionsLoop:
@@ -262,9 +263,6 @@ const ThinBridgeTalkClient = {
 
       const sectionName = (section.Name || '').toLowerCase();
       matchedSectionNames.push(sectionName);
-
-      if (config.CloseEmptyTab && isClosableTab)
-        closeTabCount++;
 
       console.log(` => matched, action = ${section.Action}`);
       if (section.Action) {
@@ -311,7 +309,7 @@ const ThinBridgeTalkClient = {
       console.log(`* Dispatch as action mode`);
       if (redirectCount > 0 || loadCount == 0) {
         console.log(`* Redirect to another browser`);
-        this.redirect(url, tabId, closeTabCount > 0);
+        this.redirect(url, tabId, closeTabOnRedirect);
       }
       console.log(`* Continue to load: ${loadCount > 0}`);
       return loadCount == 0;
@@ -327,7 +325,7 @@ const ThinBridgeTalkClient = {
 
       if (redirectCount > 0) {
         console.log(`* Redirect to another browser`);
-        this.redirect(url, tabId, closeTabCount > 0);
+        this.redirect(url, tabId, closeTabOnRedirect);
         return true;
       }
 
@@ -336,7 +334,7 @@ const ThinBridgeTalkClient = {
         if (String(config.DefaultBrowser).toLowerCase() == BROWSER.toLowerCase()) {
           return false;
         } else {
-          this.redirect(url, tabId, closeTabCount > 0);
+          this.redirect(url, tabId, closeTabOnRedirect);
           return true;
         }
       } else {

--- a/webextensions/firefox/background.js
+++ b/webextensions/firefox/background.js
@@ -229,9 +229,10 @@ const ThinBridgeTalkClient = {
 
     console.log(`* Lookup sections for ${urlToMatch}`);
 
+    const closeTabOnRedirect = config.CloseEmptyTab && isClosableTab;
+
     let loadCount     = 0;
     let redirectCount = 0;
-    let closeTabCount = 0;
     let isActionMode  = false;
     const matchedSectionNames = [];
     sectionsLoop:
@@ -248,9 +249,6 @@ const ThinBridgeTalkClient = {
 
       const sectionName = (section.Name || '').toLowerCase();
       matchedSectionNames.push(sectionName);
-
-      if (config.CloseEmptyTab && isClosableTab)
-        closeTabCount++;
 
       console.log(` => matched, action = ${section.Action}`);
       if (section.Action) {
@@ -297,7 +295,7 @@ const ThinBridgeTalkClient = {
       console.log(`* Dispatch as action mode`);
       if (redirectCount > 0 || loadCount == 0) {
         console.log(`* Redirect to another browser`);
-        this.redirect(url, tabId, closeTabCount > 0);
+        this.redirect(url, tabId, closeTabOnRedirect);
       }
       console.log(`* Continue to load: ${loadCount > 0}`);
       return loadCount == 0;
@@ -313,7 +311,7 @@ const ThinBridgeTalkClient = {
 
       if (redirectCount > 0) {
         console.log(`* Redirect to another browser`);
-        this.redirect(url, tabId, closeTabCount > 0);
+        this.redirect(url, tabId, closeTabOnRedirect);
         return true;
       }
 
@@ -322,7 +320,7 @@ const ThinBridgeTalkClient = {
         if (String(config.DefaultBrowser).toLowerCase() == BROWSER.toLowerCase()) {
           return false;
         } else {
-          this.redirect(url, tabId, closeTabCount > 0);
+          this.redirect(url, tabId, closeTabOnRedirect);
           return true;
         }
       } else {

--- a/webextensions/test/test-edge.js
+++ b/webextensions/test/test-edge.js
@@ -72,7 +72,7 @@ describe('Microsoft Edge Add-on', () => {
     it('redirect no match URL', () => {
       const url = "https://www.google.com/";
       const conf = config();
-      thinbridge_mock.expects("redirect").once().withArgs(url, tabId, !shouldCloseTab);
+      thinbridge_mock.expects("redirect").once().withArgs(url, tabId, shouldCloseTab);
       const shouldBlock = thinbridge.handleURLAndBlock(conf, tabId, url, isClosableTab);
       thinbridge_mock.verify();
       assert.equal(shouldBlock, true);
@@ -164,7 +164,7 @@ describe('Microsoft Edge Add-on', () => {
       const url = "https://www.example.com/index.html";
       const conf = config([custom18Section])
       conf.Sections[0].Excludes = [url]
-      thinbridge_mock.expects("redirect").once().withArgs(url, tabId, !shouldCloseTab);
+      thinbridge_mock.expects("redirect").once().withArgs(url, tabId, shouldCloseTab);
       const shouldBlock = thinbridge.handleURLAndBlock(conf, tabId, url, isClosableTab);
       thinbridge_mock.verify();
       assert.equal(shouldBlock, true);
@@ -183,7 +183,7 @@ describe('Microsoft Edge Add-on', () => {
           ],
         }]
       );
-      thinbridge_mock.expects("redirect").once().withArgs(url, tabId, !shouldCloseTab);
+      thinbridge_mock.expects("redirect").once().withArgs(url, tabId, shouldCloseTab);
       const shouldBlock = thinbridge.handleURLAndBlock(conf, tabId, url, isClosableTab);
       thinbridge_mock.verify();
       assert.equal(shouldBlock, true);


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

When there is no matched rule but redirected to the default browser, the empty tab should be closed automatically.


# How to verify the fixed issue:

Run the unit test, and try pre-release-verification.

## The steps to verify:

1. `cd webextensions && make test`
2. Do verification with doc/PreReleaseVerification.md

## Expected result:

All unit tests passed.
All pre-repease-verification tests passed.