### PR TITLE
GHA: Update to actions/checkout@v4

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ jobs:
   test:
     runs-on: [ ubuntu-latest ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Testing WebExtensions
         run: |
           make -C webextensions test


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

Fix following error of CI:

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-0
```

# How to verify the fixed issue:

Need to merge into master

## The steps to verify:

Merge this and rerun CI.

## Expected result:

CI passes.