### PR TITLE
doc: Fix expectation of popup window opened by IE

### DIFF
--- a/doc/verify/PreReleaseVerification.md
+++ b/doc/verify/PreReleaseVerification.md
@@ -203,11 +203,8 @@
       window.open('https://example.net/', '_blank', 'toolbar=no');
       ```
       * 期待される結果：
-        * IEモードのポップアップウィンドウが開かれ、 https://example.net/ が読み込まれる。
-   3. そのまま1分から2分待つ。
-      * 期待される結果：
-        * IEモードのポップアップウィンドウが残っている。
-        * Chromeでタブが開かれない。
+        * IEモードのポップアップウィンドウが開かれるがすぐ閉じる。
+        * Chrome上でhttps://example.net/ が読み込まれる。
 7. リダイレクト対象のURLを新規タブで開いた際の挙動の検証：
    1. Edgeで https://example.com/ を開く。
       * 期待される結果：


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

Because the target URL described in this test matches with `[Chrome]` section, it's expected behaviour is considered to be redirected to Chrome although v1.4 doesn't redirect it.

ref: https://github.com/ThinBridge/ThinBridge/pull/77#issuecomment-2162441096
internal ref: 15696-33

# How to verify the fixed issue:

N/A

## The steps to verify:

N/A

## Expected result:

N/A
