### PR TITLE
Bump Edge and Chrome extensions version to 2.2.1

### DIFF
--- a/webextensions/chrome/manifest.json
+++ b/webextensions/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 3,
 	"name": "ThinBridge",
-	"version": "2.2.0",
+	"version": "2.2.1",
 	"description": "ThinBridge for Chrome",
 	"permissions": [
 		"nativeMessaging",

--- a/webextensions/edge/manifest.json
+++ b/webextensions/edge/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 3,
 	"name": "__MSG_extName__",
-	"version": "2.2.0",
+	"version": "2.2.1",
 	"description": "__MSG_extDescription__",
 	"permissions": [
 		"nativeMessaging",


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

We are now going to release v2.2.1.

# How to verify the fixed issue:

N/A

## The steps to verify:

N/A

## Expected result:

N/A
