### PR TITLE
CI: Run not only test but also lint & build

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,4 +12,4 @@ jobs:
       - uses: actions/checkout@v4
       - name: Testing WebExtensions
         run: |
-          make -C webextensions test
+          make -C webextensions


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

Currently CI for add-ons runs only unit tests, but it should run also link & build.

# How to verify the fixed issue:

N/A

## The steps to verify:

N/A

## Expected result:

N/A
