### PR TITLE
Include adml files in subfolder

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -48,4 +48,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: Templates
-          path: Resources/GPO/*.adm*
+          path: Resources/GPO/**/*.adm*


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

`Resources\GPO\ja-JP\ThinBridge.adml` is not included in Templates.zip generated by build actions: https://github.com/ThinBridge/ThinBridge/actions/runs/9592130587
This patch modify to include `Resources\GPO\ja-JP\ThinBridge.adml`  to Templates.zip.

# How to verify the fixed issue:

## The steps to verify:

* Download Templates.zip from [an Actions result](https://github.com/ThinBridge/ThinBridge/actions/runs/9592256083)
* [x] Confirm that Templates.zip contains `ja-JP\ThinBridge.adml`.
