### PR TITLE
GHA: Use actions/checkout@v4 and actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -4,7 +4,7 @@ jobs:
   build:
     runs-on: [ windows-2019 ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: microsoft/setup-msbuild@v2
       - name: Compile x86
         run: msbuild /p:Platform=Win32 /p:Configuration=Release
@@ -17,21 +17,21 @@ jobs:
       - name: Make Installer (x64)
         run: iscc.exe ThinBridgeX64.iss
       - name: Upload Binaries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Binaries
           path: |
             Release/*.exe
             Release/*.dll
       - name: Upload Installer
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Installers
           path: SetupOutput/*.exe
   assets:
     runs-on: [ ubuntu-latest ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build Testing Extensions
         run: |
           cp webextensions/edge/manifest.json.dev webextensions/edge/manifest.json
@@ -40,12 +40,12 @@ jobs:
           make -C webextensions/chrome
           make -C webextensions/firefox
       - name: Upload Extensions
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: WebExtensions
           path: webextensions/*/*.zip
       - name: Upload GPO Templates
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Templates
           path: Resources/GPO/**/*.adm*


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

Fix following warning:
https://github.com/ThinBridge/ThinBridge/actions/runs/9606207393
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

# How to verify the fixed issue:

Check result of GitHub Actions
https://github.com/ThinBridge/ThinBridge/actions/runs/9606295593?pr=87

## The steps to verify:

Check result of GitHub Actions
https://github.com/ThinBridge/ThinBridge/actions/runs/9606295593?pr=87

## Expected result:

No warning is shown.