### PR TITLE
v1.4: Fix sub-frame transition

### DIFF
--- a/webextension/edge/manifest.json
+++ b/webextension/edge/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 2,
 	"name": "__MSG_extName__",
-	"version": "1.4.0",
+	"version": "1.4.1",
 	"description": "__MSG_extDescription__",
 	"permissions": [
 		"nativeMessaging",


### PR DESCRIPTION
 # Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

We observed that `CANCEL_REQUEST` from sub frames causes unexpected moving back on parent main frame. To avoid it, just move to a blank page at sub frames.
    
We update only Edge add-on, don't update Chrome add-on in this commit, because Manifest V2 is already out of date and no one uses our Chrome add-on in actual.


# How to verify the fixed issue:

Check sub-frame's behaviour with enabling redirect on sub-frame.

## The steps to verify:

* put the following config to C:\Program Files\ThinBridge\ThinBridgeBHO.ini
```
[GLOBAL]
@DISABLED
@TRUSTED_ZONE
@RDP_APPMODE
@DISABLE_IE_DDE

[Chrome]
@BROWSER_PATH:
@DISABLED
@REDIRECT_PAGE_ACTION:0
@CLOSE_TIMEOUT:3

[Edge]
@BROWSER_PATH:
@REDIRECT_PAGE_ACTION:0
@CLOSE_TIMEOUT:3

[Default]
@BROWSER_PATH:Chrome
@REDIRECT_PAGE_ACTION:0
@CLOSE_TIMEOUT:3

[CUSTOM18]
@BROWSER_PATH:
@REDIRECT_PAGE_ACTION:0
@CLOSE_TIMEOUT:3
*://www.fluentd.org/*
*://platform.twitter.com/*
```
* Open new tab on Edge
* Enter `https://www.fluentd.org` to location entry.

## Expected result:

* The URL `https://www.youtube.com/embed/sIVGsQgMHIo` in sub-frame is redirected to Chrome.
* The sub-frame transients to a blank page.
* The parent main frame doesn't move back to newtab:// (stay in https://www.fluentd.org).
