### PR TITLE
Edge & Chrome addon: Move to blank page on redirect from sub frames

### DIFF
--- a/doc/verify/PreReleaseVerification.md
+++ b/doc/verify/PreReleaseVerification.md
@@ -1273,3 +1273,49 @@ crxパッケージ化されたアドオンをGPOでインストールした状�
 5. Edgeを終了する。
 
 
+### サブフレームでのリダイレクトの動作検証
+
+#### 準備
+
+`C:\Program Files\ThinBridge\ThinBridgeBHO.ini` を以下の内容に設定する。
+
+```
+[GLOBAL]
+@DISABLED
+@TRUSTED_ZONE
+@RDP_APPMODE
+@DISABLE_IE_DDE
+
+[Chrome]
+@BROWSER_PATH:
+@DISABLED
+@REDIRECT_PAGE_ACTION:0
+@CLOSE_TIMEOUT:3
+
+[Edge]
+@BROWSER_PATH:
+@REDIRECT_PAGE_ACTION:0
+@CLOSE_TIMEOUT:3
+
+[Default]
+@BROWSER_PATH:Chrome
+@REDIRECT_PAGE_ACTION:0
+@CLOSE_TIMEOUT:3
+
+[CUSTOM18]
+@BROWSER_PATH:
+@REDIRECT_PAGE_ACTION:0
+@CLOSE_TIMEOUT:3
+*://www.fluentd.org/*
+*://platform.twitter.com/*
+```
+
+#### 検証
+
+1. Edgeを起動する。
+2. 新規タブを開く。
+3. URLエントリに `https://www.fluentd.org` を入力してEnterキーを押下する。
+   * 期待される結果
+     * トップフレームは https://www.fluentd.org に遷移する。
+	 * サブフレームは空白ページに遷移する。
+	 * サブフレーム内のコンテンツ https://www.youtube.com/embed/sIVGsQgMHIo がChromeにリダイレクトされる。

--- a/webextensions/chrome/background.js
+++ b/webextensions/chrome/background.js
@@ -12,7 +12,19 @@ const DMZ_SECTION = 'custom18';
 const CONTINUOUS_SECTION = 'custom19';
 const SERVER_NAME = 'com.clear_code.thinbridge';
 const ALARM_MINUTES = 0.5;
+/*
+ * When `{cancel: 1}` is used to block loading, Edge shows a warning page which
+ * indicates that loading is canceled by an add-on. To avoid it, move back to
+ * the previous page instead of blocking.
+ */
 const CANCEL_REQUEST = {redirectUrl:`data:text/html,${escape('<script type="application/javascript">history.back()</script>')}`};
+/*
+ *  Although even if we return `CANCEL_REQUEST` from `onBeforeRequest()` on a
+ *  sub frame, `history.back()` seems to be performed against it's parent main
+ *  frame. As a result main frame moves back to the previous page unexpectedly.
+ *  To avoid it, just move to blank page instead.
+ */
+const CANCEL_REQUEST_FOR_SUBFRAME = {redirectUrl:'about:blank'};
 const REDIRECT_INTERVAL_LIMIT = 1000;
 
 /*
@@ -466,8 +478,12 @@ const ThinBridgeTalkClient = {
 
     const isClosableTab = isMainFrame && (this.newTabIds.has(details.tabId) || !this.knownTabIds.has(details.tabId));
 
-    if (this.handleURLAndBlock(config, details.tabId, details.url, isClosableTab))
-      return CANCEL_REQUEST;
+    if (this.handleURLAndBlock(config, details.tabId, details.url, isClosableTab)) {
+      if (isMainFrame)
+	return CANCEL_REQUEST;
+      else
+        return CANCEL_REQUEST_FOR_SUBFRAME;
+    }
   },
 };
 

--- a/webextensions/chrome/background.js
+++ b/webextensions/chrome/background.js
@@ -20,8 +20,9 @@ const ALARM_MINUTES = 0.5;
 const CANCEL_REQUEST = {redirectUrl:`data:text/html,${escape('<script type="application/javascript">history.back()</script>')}`};
 /*
  *  Although even if we return `CANCEL_REQUEST` from `onBeforeRequest()` on a
- *  sub frame, `history.back()` seems to be performed against it's parent main
- *  frame. As a result main frame moves back to the previous page unexpectedly.
+ *  sub-frame, `history.back()` will be performed against it's parent main
+ *  frame when there is no page to back in the sub-frame. As a result main
+ *  frame moves back to the previous page unexpectedly.
  *  To avoid it, just move to blank page instead.
  */
 const CANCEL_REQUEST_FOR_SUBFRAME = {redirectUrl:'about:blank'};

--- a/webextensions/edge/background.js
+++ b/webextensions/edge/background.js
@@ -12,7 +12,19 @@ const DMZ_SECTION = 'custom18';
 const CONTINUOUS_SECTION = 'custom19';
 const SERVER_NAME = 'com.clear_code.thinbridge';
 const ALARM_MINUTES = 0.5;
+/*
+ * When `{cancel: 1}` is used to block loading, Edge shows a warning page which
+ * indicates that loading is canceled by an add-on. To avoid it, move back to
+ * the previous page instead of blocking.
+ */
 const CANCEL_REQUEST = {redirectUrl:`data:text/html,${escape('<script type="application/javascript">history.back()</script>')}`};
+/*
+ *  Although even if we return `CANCEL_REQUEST` from `onBeforeRequest()` on a
+ *  sub frame, `history.back()` seems to be performed against it's parent main
+ *  frame. As a result main frame moves back to the previous page unexpectedly.
+ *  To avoid it, just move to blank page instead.
+ */
+const CANCEL_REQUEST_FOR_SUBFRAME = {redirectUrl:'about:blank'};
 const REDIRECT_INTERVAL_LIMIT = 1000;
 
 /*
@@ -466,8 +478,12 @@ const ThinBridgeTalkClient = {
 
     const isClosableTab = isMainFrame && (this.newTabIds.has(details.tabId) || !this.knownTabIds.has(details.tabId));
 
-    if (this.handleURLAndBlock(config, details.tabId, details.url, isClosableTab))
-      return CANCEL_REQUEST;
+    if (this.handleURLAndBlock(config, details.tabId, details.url, isClosableTab)) {
+      if (isMainFrame)
+	return CANCEL_REQUEST;
+      else
+        return CANCEL_REQUEST_FOR_SUBFRAME;
+    }
   },
 };
 

--- a/webextensions/edge/background.js
+++ b/webextensions/edge/background.js
@@ -20,8 +20,9 @@ const ALARM_MINUTES = 0.5;
 const CANCEL_REQUEST = {redirectUrl:`data:text/html,${escape('<script type="application/javascript">history.back()</script>')}`};
 /*
  *  Although even if we return `CANCEL_REQUEST` from `onBeforeRequest()` on a
- *  sub frame, `history.back()` seems to be performed against it's parent main
- *  frame. As a result main frame moves back to the previous page unexpectedly.
+ *  sub-frame, `history.back()` will be performed against it's parent main
+ *  frame when there is no page to back in the sub-frame. As a result main
+ *  frame moves back to the previous page unexpectedly.
  *  To avoid it, just move to blank page instead.
  */
 const CANCEL_REQUEST_FOR_SUBFRAME = {redirectUrl:'about:blank'};


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

We observed that CANCEL_REQUEST from sub frames causes unexpected moving back on parent main frame. To avoid it, just move to a blank page at sub frames.

# How to verify the fixed issue:

Check sub-frame's behaviour with enabling redirect on sub-frame.

## The steps to verify:

* put the following config to C:\Program Files\ThinBridge\ThinBridgeBHO.ini
```
[GLOBAL]
@DISABLED
@TRUSTED_ZONE
@RDP_APPMODE
@DISABLE_IE_DDE

[Chrome]
@BROWSER_PATH:
@DISABLED
@REDIRECT_PAGE_ACTION:0
@CLOSE_TIMEOUT:3

[Edge]
@BROWSER_PATH:
@REDIRECT_PAGE_ACTION:0
@CLOSE_TIMEOUT:3

[Default]
@BROWSER_PATH:Chrome
@REDIRECT_PAGE_ACTION:0
@CLOSE_TIMEOUT:3

[CUSTOM18]
@BROWSER_PATH:
@REDIRECT_PAGE_ACTION:0
@CLOSE_TIMEOUT:3
*://www.fluentd.org/*
*://platform.twitter.com/*
```
* Open new tab on Edge
* Enter `https://www.fluentd.org` to location entry.

## Expected result:

* The URL `https://www.youtube.com/embed/sIVGsQgMHIo` in sub-frame is redirected to Chrome.
* The sub-frame transients to a blank page.
* The parent main frame doesn't move back to newtab:// (stay in https://www.fluentd.org).
