### PR TITLE
Chrome & Edge add-on: Fix wrong tabId specifier for chrome.scripting.executeScript

### DIFF
--- a/webextensions/chrome/background.js
+++ b/webextensions/chrome/background.js
@@ -433,7 +433,7 @@ const ThinBridgeTalkClient = {
      * Then let the tab go back to the previous page.
      */
     chrome.scripting.executeScript({
-      target: { tabId },
+      target: { tabId: tabId },
       func: function goBack() {
         window.stop();
         window.history.back();

--- a/webextensions/edge/background.js
+++ b/webextensions/edge/background.js
@@ -433,7 +433,7 @@ const ThinBridgeTalkClient = {
      * Then let the tab go back to the previous page.
      */
     chrome.scripting.executeScript({
-      target: { tabId },
+      target: { tabId: tabId },
       func: function goBack() {
         window.stop();
         window.history.back();


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

It seems that wrong object is passed as `target` of `chrome.scripting.executeScript`.
ref: https://developer.chrome.com/docs/extensions/reference/api/scripting#type-InjectionTarget

# How to verify the fixed issue:

Verify [onTabUpdated()によるリダイレクトの動作検証](https://github.com/ThinBridge/ThinBridge/blob/master/doc/verify/PreReleaseVerification.md#ontabupdated%E3%81%AB%E3%82%88%E3%82%8B%E3%83%AA%E3%83%80%E3%82%A4%E3%83%AC%E3%82%AF%E3%83%88%E3%81%AE%E5%8B%95%E4%BD%9C%E6%A4%9C%E8%A8%BC) isn't broken.

## The steps to verify:

Ditto.

## Expected result:

Ditto.
