### PR TITLE
Bump Edge and Chrome extensions version to 2.3.0

### DIFF
--- a/webextensions/chrome/manifest.json
+++ b/webextensions/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 3,
 	"name": "ThinBridge",
-	"version": "2.2.1",
+	"version": "2.3.0",
 	"description": "ThinBridge for Chrome",
 	"permissions": [
 		"nativeMessaging",

--- a/webextensions/edge/manifest.json
+++ b/webextensions/edge/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 3,
 	"name": "__MSG_extName__",
-	"version": "2.2.1",
+	"version": "2.3.0",
 	"description": "__MSG_extDescription__",
 	"permissions": [
 		"nativeMessaging",


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

We may provide fixes in #90 #94 only for a particular customer for a while, and might not release it to store soon.
Until release it, other minor fixes might be added to store's version.
So we bump up the minor version of the former one to distinguish and manage them individually.

# How to verify the fixed issue:

N/A

## The steps to verify:

N/A

## Expected result:

N/A
