### PR TITLE
[Draft] Add document to describe how to distribute ThinBridge extension from internal servers

### DIFF
--- a/doc/InternalDistributionGuide.md
+++ b/doc/InternalDistributionGuide.md
@@ -1,0 +1,838 @@
+---
+CJKmainfont: Noto Sans CJK JP
+CJKoptions:
+  - BoldFont=Noto Sans CJK JP Bold
+title: "ThinBridge拡張機能 組織内サーバーを用いた配布・更新手順"
+author: "株式会社クリアコード"
+date: "2024-07-22"
+titlepage: true
+colorlinks: true
+toc-title: "目次"
+toc-own-page: true
+listings-disable-line-numbers: true
+code-block-font-size: \footnotesize
+footnotes-pretty: true
+---
+
+# 目的
+
+本手順書は、Active Directoryドメイン参加端末を対象として、組織内サーバーを使用してMicrosoft Edge用およびGoogle Chrome用ThinBridge拡張機能（以下、ThinBridge拡張機能）を配布する手順をまとめたものです。
+
+# 概要
+
+ThinBridge拡張機能は、ADドメイン参加端末に対してグループポリシー（GPO）で導入のための設定を行い、設定を認識した各端末のEdgeおよびChrome（以下、ブラウザー）が、ThinBridge拡張機能のファイルをダウンロードしてくることによりインストールされます。
+
+通常、GPOを用いた拡張機能のインストール時には、拡張機能のファイルはMicrosoftのWebストアからインストールされます。この場合、ブラウザーおよびWebストアの仕様により、インストールされる拡張機能は常にWebストア上の最新バージョンとなり、それ以外の任意のバージョンを使用することはできません。
+
+本手順書では、Webストアからではなく組織内サーバーからThinBridge拡張機能の更新情報を取得するようにGPOを設定することにより、当該サーバーに設置した任意のバージョンのThinBridge拡張機能を、ADドメイン参加端末へ新規または更新の形で一斉インストールさせる手順を説明します。
+
+
+# 前提
+
+本項目の作業手順は以下の作業環境で実施することを想定します。
+
+* 作業者：システム管理者 1名
+* 作業環境：Active Directoryドメインコントローラーを操作可能なWindows端末 1台
+* 適用時に必要なサーバー：全端末からアクセス可能なファイル配布用サーバー 1台
+  * Windowsファイル共有サーバー、もしくはWWWサーバーが必要です。
+  * 本サーバーはドメインコントローラーとの兼用可です。
+
+
+
+# ThinBridge拡張機能の組織内サーバーからのインストール
+
+## 一部の検証対象端末を対象としたインストール（事前検証）
+
+全体展開前の検証のために、ADドメイン参加端末のうち、情報システム部門のみの端末など、一部の端末のみを対象として、ThinBridge拡張機能を組織内サーバーで配布する形で新規に導入する場合、もしくは、組織内サーバーでの配布を行っていなかった状態から組織内サーバーでの配布へ切り替える場合について、手順の大まかな流れは以下の通りです。
+
+1. GPOによるThinBridge拡張機能の新規インストール
+2. GPOによる`edge.json`および`chrome.json`の書き換え
+3. 端末でThinBridge拡張機能が新規インストールされたことの確認
+
+以下に具体的な作業手順を記します。
+
+1. **GPOによるThinBridge拡張機能の新規インストール**  
+   組織内サーバーに設置したThinBridge拡張機能をインストールするため、グループポリシーの設定を変更します。  
+   以下の作業はすべて、作業環境にて、システム管理者が管理者ユーザーアカウントで実施します。
+   1. 全端末からアクセス可能なファイル配布用サーバー上に、一般ユーザー権限で読み取り可能な、ファイル配布用フォルダーを作成します。  
+      以下、コンピューター名/ホスト名が「fileserver」であるWindowsファイル共有サーバーを使用し、ファイル配布用フォルダー名は「thinbridge-test」を使用するものと仮定します。  
+      この仮定に従い、ファイル共有サーバー上に作成された共有フォルダーのUNCパスが  
+      `\\fileserver\thinbridge-test\`  
+      となると仮定します。
+   2. 組織内配布用の各ブラウザー用crxファイル（`ThinBridgeEdge-vX.X.X.crx`、`ThinBridgeChrome-vX.X.X.crx`）、組織内配布用の各ブラウザー用Native Manifestファイル（`edge.json`、`chrome.json`）、組織内配布用の更新情報ファイル（`manifest.xml`）をダウンロードします。  
+      バージョン2.2.1をインストールすると仮定すると、使用するcrxファイルは
+      
+      * `ThinBridgeEdge-v2.2.1.crx`
+      * `ThinBridgeChrome-v2.2.1.crx`
+      
+      となります。
+   3. 1.2で取得した5つのファイルを、1.1で作成したファイル配布用フォルダーに設置します。  
+      前述の仮定に従い、各ファイルのUNCパスは
+      
+      * `\\fileserver\thinbridge-test\ThinBridgeEdge-v2.2.1.crx`
+      * `\\fileserver\thinbridge-test\ThinBridgeChrome-v2.2.1.crx`
+      * `\\fileserver\thinbridge-test\edge.json`
+      * `\\fileserver\thinbridge-test\chrome.json`
+      * `\\fileserver\thinbridge-test\manifest.xml`
+      
+      となると仮定します。
+   4. 1.3で設置した`manifest.xml`を「メモ帳」もしくは何らかのテキスト編集ツールで開き、ファイルが以下のような内容であることを確認します。
+      
+      ```xml
+      <?xml version='1.0' encoding='UTF-8'?>
+      <gupdate xmlns='http://www.google.com/update2/response' protocol='2.0'>
+        <app appid='jcamehnjflombcdhafhiogbojgghefec'>
+          <updatecheck
+            codebase='（ThinBridgeEdge-vX.X.X.crxのURL）'
+            version='（バージョン番号）' />
+        </app>
+        <app appid='XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'>
+          <updatecheck
+            codebase='（ThinBridgeChrome-vX.X.X.crxのURL）'
+            version='（バージョン番号）' />
+        </app>
+      </gupdate>
+      ```
+   5. 1.4で開いたファイルの`codebase='`から`'`までの間の箇所を、1.3で設置した実際のcrxファイルのURLで置き換えます。  
+      また、`version ='`から`'`までの間の箇所を、インストールするThinBridge拡張機能のバージョンで置き換えます。  
+      前述の仮定に従うと、ファイルのURLはUNCパスに基づいて
+      
+      * `file://fileserver/thinbridge-test/ThinBridgeEdge-v2.2.1.crx`
+      * `file://fileserver/thinbridge-test/ThinBridgeChrome-v2.2.1.crx`
+      
+      となり、ThinBridge拡張機能バージョン2.2.1をインストールする場合の編集後の`manifest.xml`の内容は以下の要領となります。
+      
+      ```xml
+      <?xml version='1.0' encoding='UTF-8'?>
+      <gupdate xmlns='http://www.google.com/update2/response' protocol='2.0'>
+        <app appid='jcamehnjflombcdhafhiogbojgghefec'>
+          <updatecheck
+            codebase='file://fileserver/thinbridge-test/ThinBridgeEdge-v2.2.1.crx'
+            version='2.2.1' />
+        </app>
+        <app appid='XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'>
+          <updatecheck
+            codebase='file://fileserver/thinbridge-test/ThinBridgeChrome-v2.2.1.crx'
+            version='2.2.1' />
+        </app>
+      </gupdate>
+      ```
+   6. 編集後の`manifest.xml`を上書き保存します。
+   7. 配置した各ファイルの「プロパティ」を開き、「セキュリティ」タブを選択して、当該ファイルが「Everyone」で読み取り可能な状態になっていることを確認します。  
+      もしそのようになっていない場合は、以下の手順でファイルを「Everyone」で読み取り可能な状態に設定します。
+      
+      1. 「編集」ボタンをクリックします。
+      2. 開かれたダイアログ内で「追加」ボタンをクリックします。
+      3. 開かれたダイアログ内で「選択するオブジェクト名を入力してください」欄に「Everyone」と入力します。
+      4. 「OK」ボタンを押してダイアログを閉じる操作を3回繰り返します。
+   8. 検証対象の端末に一般ユーザーでログインし、1.3で配置した5つのファイルを読み取れることを確認します。
+      
+      * `manifest.xml`のURL（前述の仮定に従うと`file://fileserver/thinbridge-test/manifest.xml`）をEdgeで開き、1.6で設定した通りの内容を読み取れることを確認します。
+      * Edge用crxのURL（前述の仮定に従うと`file://fileserver/thinbridge-test/ThinBridgeEdge-v2.2.1.crx`）をEdgeで開き、ファイルがダウンロード可能であることを確認します。
+      * Chrome用crxのURL（前述の仮定に従うと`file://fileserver/thinbridge-test/ThinBridgeChrome-v2.2.1.crx`）をChromeで開き、ファイルがダウンロード可能であることを確認します。
+      * `edge.json`、`chrome.json`をメモ帳などで開き、内容を閲覧できることを確認します。
+   9. グループポリシー管理コンソールを起動します。
+   10. 検証対象の端末の一般ユーザーに適用するためのGPOを作成、もしくは検証対象の端末の一般ユーザーに適用されるGPOを用意します。  
+       ここでは例として、「ThinBridge拡張機能（事前検証）」という名称のGPOを使用するものとします。
+   11. 1.10で用意したGPOについて、  
+       「管理用テンプレート」  
+       →「Microsoft Edge」  
+       →「拡張機能」  
+       →「サイレント インストールされる拡張機能を制御する」  
+       をダブルクリックして、当該ポリシーの設定画面を開きます。
+   12. 設定の状態を「有効」に設定します。
+   13. 「表示...」をクリックして、値の設定画面を開きます。
+   14. 以下の項目が存在する場合、項目を削除します。
+       
+       * `jcamehnjflombcdhafhiogbojgghefec`
+       * `famoofbkcpjdkihdngnhgbdfkfenhcnf`
+   15. 以下の項目を追加します。
+       
+       * `jcamehnjflombcdhafhiogbojgghefec;（manifest.xmlのURL）`
+       
+       前述の仮定に従うと、追加する項目は以下の要領となります。
+       
+       * `jcamehnjflombcdhafhiogbojgghefec;file://fileserver/thinbridge-test/manifest.xml`
+   16. 「OK」ボタンを押して、値の設定画面を閉じます。
+   17. 「OK」ボタンを押して、ポリシーの設定画面を閉じます。
+   18. 1.10で用意したGPOについて、  
+       「管理用テンプレート」  
+       →「Google」  
+       →「Coogle Chrome」  
+       →「拡張機能」  
+       →「自動インストールするアプリと拡張機能のリストの設定」  
+       をダブルクリックして、当該ポリシーの設定画面を開きます。
+   19. 設定の状態を「有効」に設定します。
+   20. 「表示...」をクリックして、値の設定画面を開きます。
+   21. 以下の項目が存在する場合、項目を削除します。
+       
+       * `XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX`
+       * `iiajmhibpjkpmfmbhegccdfmfnfeffmh`
+   22. 以下の項目を追加します。
+       
+       * `XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX;（manifest.xmlのURL）`
+       
+       前述の仮定に従うと、追加する項目は以下の要領となります。
+       
+       * `XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX;file://fileserver/thinbridge-test/manifest.xml`
+   23. 「OK」ボタンを押して、値の設定画面を閉じます。
+   24. 「OK」ボタンを押して、ポリシーの設定画面を閉じます。
+2. **GPOによる`edge.json`および`chrome.json`の書き換え**  
+   組織内サーバーから配布されたThinBridge拡張機能によるThinBridge本体の呼び出し要求を許可するため、`edge.json`および`chrome.json`の配布のための設定を行います。  
+   以下の作業はすべて、作業環境にて、システム管理者が管理者ユーザーアカウントで実施します。
+   1. グループポリシー管理コンソールで、検証対象の端末の一般ユーザーに適用されるGPO（「ThinBridge拡張機能（事前検証）」と仮定）について、  
+      「ユーザーの構成」  
+      →「基本設定」  
+      →「Windowsの設定」  
+      →「ファイル」  
+      を右クリックし「新規作成」から「ファイル」を選択します。
+   2. 以下の通り設定します。
+      
+      * アクション：「置換」を選択。
+      * ソースファイル：1.3で配置した`edge.json`を、全端末から参照可能なUNCパスで指定。（例：`\\fileserver\thinbridge-test\edge.json`）
+      * ターゲットファイル：`C:\Program Files\ThinBridge\ThinBridgeHost\edge.json`を指定。
+      * 属性：「読み取り専用」のみにチェック。
+   3. 続いて、  
+      「ユーザーの構成」  
+      →「基本設定」  
+      →「Windowsの設定」  
+      →「ファイル」  
+      を右クリックし「新規作成」から「ファイル」を選択します。
+   2. 以下の通り設定します。
+      
+      * アクション：「置換」を選択。
+      * ソースファイル：1.3で配置した`chrome.json`を、全端末から参照可能なUNCパスで指定。（例：`\\fileserver\thinbridge-test\chrome.json`）
+      * ターゲットファイル：`C:\Program Files\ThinBridge\ThinBridgeHost\chrome.json`を指定。
+      * 属性：「読み取り専用」のみにチェック。
+3. **端末でThinBridge拡張機能がインストールされたことの確認**  
+   端末の強制再起動などを行い、グループポリシーが検証対象の端末に反映された状態として下さい。
+   
+   以下にグループポリシーの反映を確認する手順を示します。  
+   以下の作業はすべて、ADドメイン参加状態の検証対象の端末にて、システム管理者または一般ユーザーが一般ユーザーアカウントで実施します。
+   
+   1. `C:\Program Files\ThinBridge\ThinBridgeHost\`配下の`edge.json`をメモ帳で開き、前項で配布するよう設定したファイルの通りの内容になっている（ファイルが配信されている）ことを確認します。
+   2. Edgeを起動します。
+   3. 数秒待ち、Edgeのツールバー上にパズルピース型のボタンが表示されることを確認します。
+   4. Edgeのツールバー上にパズルピース型のボタンをクリックし、「拡張機能の管理」をクリックします。
+   5. 拡張機能の管理画面が開かれますので、「インストール済の拡張機能」の一覧に以下の項目が存在する事を確認します。
+      
+      * ThinBridge
+   6. 項目の詳細情報を表示し、バージョンが組織内サーバーで配布しているバージョンと一致していることを確認します。
+   7. `C:\Program Files\ThinBridge\ThinBridgeHost\`配下の`chrome.json`をメモ帳で開き、前項で配布するよう設定したファイルの通りの内容になっている（ファイルが配信されている）ことを確認します。
+   8. Chromeを起動します。
+   9. 数秒待ち、Chromeのツールバー上にパズルピース型のボタンが表示されることを確認します。
+   10. Chromeのツールバー上にパズルピース型のボタンをクリックし、「拡張機能を管理」をクリックします。
+   11. 拡張機能の管理画面が開かれますので、「すべての拡張機能」の一覧に以下の項目が存在する事を確認します。
+      
+       * ThinBridge
+   12. 項目の詳細情報を表示し、バージョンが組織内サーバーで配布しているバージョンと一致していることを確認します。
+
+以上の手順により、組織内サーバーに設置したバージョンのThinBridge拡張機能が、検証対象の端末にインストールされます。
+
+## 全端末を対象としたインストール（本番展開）
+
+ADドメイン参加端末全体を対象として、ThinBridge拡張機能を組織内サーバーで配布する形で新規に導入する場合、もしくは、組織内サーバーでの配布を行っていなかった状態から組織内サーバーでの配布へ切り替える場合について、手順の大まかな流れは以下の通りです。
+
+1. GPOによるThinBridge拡張機能の新規インストール
+2. GPOによる`edge.json`および`chrome.json`の書き換え
+3. 端末でThinBridge拡張機能が新規インストールされたことの確認
+
+以下に、具体的な作業手順を記します。
+
+1. **GPOによるThinBridge拡張機能の新規インストール**  
+   組織内サーバーに設置したThinBridge拡張機能をインストールするため、グループポリシーの設定を変更します。  
+   以下の作業はすべて、作業環境にて、システム管理者が管理者ユーザーアカウントで実施します。
+   1. 全端末からアクセス可能なファイル配布用サーバー上に、一般ユーザー権限で読み取り可能な、事前検証用とは別のファイル配布用フォルダーを作成します。  
+      以下、コンピューター名/ホスト名が「fileserver」であるWindowsファイル共有サーバーを使用し、ファイル配布用フォルダー名は「thinbridge」を使用するものと仮定します。  
+      この仮定に従い、ファイル共有サーバー上に作成された共有フォルダーのUNCパスが  
+      `\\fileserver\thinbridge\`  
+      となると仮定します。
+   2. 組織内配布用の各ブラウザー用crxファイル（`ThinBridgeEdge-vX.X.X.crx`、`ThinBridgeChrome-vX.X.X.crx`）、組織内配布用の各ブラウザー用Native Manifestファイル（`edge.json`、`chrome.json`）、組織内配布用の更新情報ファイル（`manifest.xml`）をダウンロードします。  
+      バージョン2.2.1をインストールすると仮定すると、使用するcrxファイルは
+      
+      * `ThinBridgeEdge-v2.2.1.crx`
+      * `ThinBridgeChrome-v2.2.1.crx`
+      
+      となります。
+   3. 1.2で取得した5つのファイルを、1.1で作成したファイル配布用フォルダーに設置します。  
+      前述の仮定に従い、各ファイルのUNCパスは
+      
+      * `\\fileserver\thinbridge\ThinBridgeEdge-v2.2.1.crx`
+      * `\\fileserver\thinbridge\ThinBridgeChrome-v2.2.1.crx`
+      * `\\fileserver\thinbridge\edge.json`
+      * `\\fileserver\thinbridge\chrome.json`
+      * `\\fileserver\thinbridge\manifest.xml`
+      
+      となると仮定します。
+   4. 1.3で設置した`manifest.xml`を「メモ帳」もしくは何らかのテキスト編集ツールで開き、ファイルが以下のような内容であることを確認します。
+      
+      ```xml
+      <?xml version='1.0' encoding='UTF-8'?>
+      <gupdate xmlns='http://www.google.com/update2/response' protocol='2.0'>
+        <app appid='jcamehnjflombcdhafhiogbojgghefec'>
+          <updatecheck
+            codebase='（ThinBridgeEdge-vX.X.X.crxのURL）'
+            version='（バージョン番号）' />
+        </app>
+        <app appid='XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'>
+          <updatecheck
+            codebase='（ThinBridgeChrome-vX.X.X.crxのURL）'
+            version='（バージョン番号）' />
+        </app>
+      </gupdate>
+      ```
+   5. 1.4で開いたファイルの`codebase='`から`'`までの間の箇所を、1.3で設置した実際のcrxファイルのURLで置き換えます。  
+      また、`version ='`から`'`までの間の箇所を、インストールするThinBridge拡張機能のバージョンで置き換えます。  
+      前述の仮定に従うと、ファイルのURLはUNCパスに基づいて
+      
+      * `file://fileserver/thinbridge/ThinBridgeEdge-v2.2.1.crx`
+      * `file://fileserver/thinbridge/ThinBridgeChrome-v2.2.1.crx`
+      
+      となり、ThinBridge拡張機能バージョン2.2.1をインストールする場合の編集後の`manifest.xml`の内容は以下の要領となります。
+      
+      ```xml
+      <?xml version='1.0' encoding='UTF-8'?>
+      <gupdate xmlns='http://www.google.com/update2/response' protocol='2.0'>
+        <app appid='jcamehnjflombcdhafhiogbojgghefec'>
+          <updatecheck
+            codebase='file://fileserver/thinbridge/ThinBridgeEdge-v2.2.1.crx'
+            version='2.2.1' />
+        </app>
+        <app appid='XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'>
+          <updatecheck
+            codebase='file://fileserver/thinbridge/ThinBridgeChrome-v2.2.1.crx'
+            version='2.2.1' />
+        </app>
+      </gupdate>
+      ```
+   6. 編集後の`manifest.xml`を上書き保存します。
+   7. 配置した各ファイルの「プロパティ」を開き、「セキュリティ」タブを選択して、当該ファイルが「Everyone」で読み取り可能な状態になっていることを確認します。  
+      もしそのようになっていない場合は、以下の手順でファイルを「Everyone」で読み取り可能な状態に設定します。
+      
+      1. 「編集」ボタンをクリックします。
+      2. 開かれたダイアログ内で「追加」ボタンをクリックします。
+      3. 開かれたダイアログ内で「選択するオブジェクト名を入力してください」欄に「Everyone」と入力します。
+      4. 「OK」ボタンを押してダイアログを閉じる操作を3回繰り返します。
+   8. 検証対象の端末に一般ユーザーでログインし、1.3で配置した5つのファイルを読み取れることを確認します。
+      
+      * `manifest.xml`のURL（前述の仮定に従うと`file://fileserver/thinbridge/manifest.xml`）をEdgeで開き、1.6で設定した通りの内容を読み取れることを確認します。
+      * Edge用crxのURL（前述の仮定に従うと`file://fileserver/thinbridge/ThinBridgeEdge-v2.2.1.crx`）をEdgeで開き、ファイルがダウンロード可能であることを確認します。
+      * Chrome用crxのURL（前述の仮定に従うと`file://fileserver/thinbridge/ThinBridgeChrome-v2.2.1.crx`）をChromeで開き、ファイルがダウンロード可能であることを確認します。
+      * `edge.json`、`chrome.json`をメモ帳などで開き、内容を閲覧できることを確認します。
+   9. グループポリシー管理コンソールを起動します。
+   10. 全端末の一般ユーザーに適用するためのGPOを作成、もしくは全端末の一般ユーザーに適用されるGPOを用意します。  
+       ここでは例として、「ThinBridge拡張機能」という名称のGPOを使用するものとします。
+   11. 1.10で用意したGPOについて、  
+       「管理用テンプレート」  
+       →「Microsoft Edge」  
+       →「拡張機能」  
+       →「サイレント インストールされる拡張機能を制御する」  
+       をダブルクリックして、当該ポリシーの設定画面を開きます。
+   12. 設定の状態を「有効」に設定します。
+   13. 「表示...」をクリックして、値の設定画面を開きます。
+   14. 以下の項目が存在する場合、項目を削除します。
+       
+       * `jcamehnjflombcdhafhiogbojgghefec`
+       * `famoofbkcpjdkihdngnhgbdfkfenhcnf`
+   15. 以下の項目を追加します。
+       
+       * `jcamehnjflombcdhafhiogbojgghefec;（manifest.xmlのURL）`
+       
+       前述の仮定に従うと、追加する項目は以下の要領となります。
+       
+       * `jcamehnjflombcdhafhiogbojgghefec;file://fileserver/thinbridge/manifest.xml`
+   16. 「OK」ボタンを押して、値の設定画面を閉じます。
+   17. 「OK」ボタンを押して、ポリシーの設定画面を閉じます。
+   18. 1.10で用意したGPOについて、  
+       「管理用テンプレート」  
+       →「Google」  
+       →「Coogle Chrome」  
+       →「拡張機能」  
+       →「自動インストールするアプリと拡張機能のリストの設定」  
+       をダブルクリックして、当該ポリシーの設定画面を開きます。
+   19. 設定の状態を「有効」に設定します。
+   20. 「表示...」をクリックして、値の設定画面を開きます。
+   21. 以下の項目が存在する場合、項目を削除します。
+       
+       * `XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX`
+       * `iiajmhibpjkpmfmbhegccdfmfnfeffmh`
+   22. 以下の項目を追加します。
+       
+       * `XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX;（manifest.xmlのURL）`
+       
+       前述の仮定に従うと、追加する項目は以下の要領となります。
+       
+       * `XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX;file://fileserver/thinbridge/manifest.xml`
+   23. 「OK」ボタンを押して、値の設定画面を閉じます。
+   24. 「OK」ボタンを押して、ポリシーの設定画面を閉じます。
+2. **GPOによる`edge.json`および`chrome.json`の書き換え**  
+   組織内サーバーから配布されたThinBridge拡張機能によるThinBridge本体の呼び出し要求を許可するため、`edge.json`および`chrome.json`の配布のための設定を行います。  
+   以下の作業はすべて、作業環境にて、システム管理者が管理者ユーザーアカウントで実施します。
+   1. グループポリシー管理コンソールで、全端末の一般ユーザーに適用されるGPO（「ThinBridge拡張機能」と仮定）について、  
+      「ユーザーの構成」  
+      →「基本設定」  
+      →「Windowsの設定」  
+      →「ファイル」  
+      を右クリックし「新規作成」から「ファイル」を選択します。
+   2. 以下の通り設定します。
+      
+      * アクション：「置換」を選択。
+      * ソースファイル：1.3で配置した`edge.json`を、全端末から参照可能なUNCパスで指定。（例：`\\fileserver\thinbridge\edge.json`）
+      * ターゲットファイル：`C:\Program Files\ThinBridge\ThinBridgeHost\edge.json`を指定。
+      * 属性：「読み取り専用」のみにチェック。
+   3. 続いて、  
+      「ユーザーの構成」  
+      →「基本設定」  
+      →「Windowsの設定」  
+      →「ファイル」  
+      を右クリックし「新規作成」から「ファイル」を選択します。
+   2. 以下の通り設定します。
+      
+      * アクション：「置換」を選択。
+      * ソースファイル：1.3で配置した`chrome.json`を、全端末から参照可能なUNCパスで指定。（例：`\\fileserver\thinbridge\chrome.json`）
+      * ターゲットファイル：`C:\Program Files\ThinBridge\ThinBridgeHost\chrome.json`を指定。
+      * 属性：「読み取り専用」のみにチェック。
+3. **端末でThinBridge拡張機能がインストールされたことの確認**  
+   端末の強制再起動などを行い、グループポリシーが検証対象の端末に反映された状態として下さい。
+   
+   以下にグループポリシーの反映を確認する手順を示します。  
+   以下の作業はすべて、任意のADドメイン参加端末にて、システム管理者または一般ユーザーが一般ユーザーアカウントで実施します。  
+   全台で確認することは不可能ですので、何台か抽出して確認されることを推奨します。
+   
+   1. `C:\Program Files\ThinBridge\ThinBridgeHost\`配下の`edge.json`をメモ帳で開き、前項で配布するよう設定したファイルの通りの内容になっている（ファイルが配信されている）ことを確認します。
+   2. Edgeを起動します。
+   3. 数秒待ち、Edgeのツールバー上にパズルピース型のボタンが表示されることを確認します。
+   4. Edgeのツールバー上にパズルピース型のボタンをクリックし、「拡張機能の管理」をクリックします。
+   5. 拡張機能の管理画面が開かれますので、「インストール済の拡張機能」の一覧に以下の項目が存在する事を確認します。
+      
+      * ThinBridge
+   6. 項目の詳細情報を表示し、バージョンが組織内サーバーで配布しているバージョンと一致していることを確認します。
+   7. `C:\Program Files\ThinBridge\ThinBridgeHost\`配下の`chrome.json`をメモ帳で開き、前項で配布するよう設定したファイルの通りの内容になっている（ファイルが配信されている）ことを確認します。
+   8. Chromeを起動します。
+   9. 数秒待ち、Chromeのツールバー上にパズルピース型のボタンが表示されることを確認します。
+   10. Chromeのツールバー上にパズルピース型のボタンをクリックし、「拡張機能を管理」をクリックします。
+   11. 拡張機能の管理画面が開かれますので、「すべての拡張機能」の一覧に以下の項目が存在する事を確認します。
+      
+       * ThinBridge
+   12. 項目の詳細情報を表示し、バージョンが組織内サーバーで配布しているバージョンと一致していることを確認します。
+
+以上の手順により、組織内サーバーに設置したバージョンのThinBridge拡張機能が、各端末に導入されます。
+
+
+# ThinBridge拡張機能の組織内サーバーからの更新
+
+## 一部の検証対象端末を対象とした更新（事前検証）
+
+全体展開前の検証のために、ADドメイン参加端末のうち、情報システム部門のみの端末など、一部の端末のみを対象として、ThinBridge拡張機能を組織内サーバーで配布する形で新バージョンへ更新する場合について、手順の大まかな流れは以下の通りです。
+
+1. GPOによるThinBridge拡張機能の更新
+2. 端末でThinBridge拡張機能が更新されたことの確認
+
+**ThinBridge拡張機能の組織内サーバーからのインストール時に、事前検証と本番展開で同一のファイル配布用フォルダーを使用していた場合には、以下に記す手順では、検証対象の一部の端末のみを対象として更新を実施することができません。その場合、「ThinBridge拡張機能の組織内サーバーからのインストール」の「一部の検証対象端末を対象としたインストール（事前検証）」に記載の手順に則り、検証対象の端末について、事前検証用のファイル配布用フォルダーに設置した`manifest.xml`およびcrxファイルが使用される状態にあらかじめ変更しておいて下さい。**
+
+以下に、検証対象の端末用に事前検証用のファイル配布用フォルダーが使われている状態を前提として、具体的な作業手順を記します。
+
+1. **GPOによるThinBridge拡張機能の更新**  
+   組織内サーバーに更新先バージョンのThinBridge拡張機能のファイルを設置します。  
+   以下の作業はすべて、作業環境にて、システム管理者が管理者ユーザーアカウントで実施します。
+   1. ファイル配布サーバー上の検証対象の端末用のファイル配布用フォルダーを開きます。  
+      「ThinBridge拡張機能の組織内サーバーからのインストール」での仮定に従い、コンピューター名/ホスト名が「fileserver」であるWindowsファイル共有サーバーを使用し、ファイル配布用フォルダー名は「thinbridge-test」を使用するものと仮定します。
+   2. 新バージョンの、組織内配布用の各ブラウザー用crxファイル（`ThinBridgeEdge-vX.X.X.crx`、`ThinBridgeChrome-vX.X.X.crx`）をダウンロードします。  
+      バージョン2.3.0へ更新すると仮定すると、使用するcrxファイルは
+      
+      * `ThinBridgeEdge-v2.3.0.crx`
+      * `ThinBridgeChrome-v2.3.0.crx`
+      
+      となります。
+   3. 新バージョンのcrxファイルを、1.1で開いたファイル配布用フォルダーに設置します。  
+      前述の仮定に従い、各ファイルのUNCパスは
+      
+      * `\\fileserver\thinbridge-test\ThinBridgeEdge-v2.3.0.crx`
+      * `\\fileserver\thinbridge-test\ThinBridgeChrome-v2.3.0.crx`
+      
+      となると仮定します。
+   4. ファイル配布用フォルダー内の`manifest.xml`を「メモ帳」もしくは何らかのテキスト編集ツールで開き、ファイルが以下のような内容であることを確認します。
+      
+      ```xml
+      <?xml version='1.0' encoding='UTF-8'?>
+      <gupdate xmlns='http://www.google.com/update2/response' protocol='2.0'>
+        <app appid='jcamehnjflombcdhafhiogbojgghefec'>
+          <updatecheck
+            codebase='（ThinBridgeEdge-vX.X.X.crxのURL）'
+            version='（バージョン番号）' />
+        </app>
+        <app appid='XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'>
+          <updatecheck
+            codebase='（ThinBridgeChrome-vX.X.X.crxのURL）'
+            version='（バージョン番号）' />
+        </app>
+      </gupdate>
+      ```
+   5. 1.4で開いたファイルの`codebase='`から`'`までの間の箇所を、1.3で設置した実際のcrxファイルのURLで置き換えます。  
+      また、`version ='`から`'`までの間の箇所を、更新先のThinBridge拡張機能のバージョンで置き換えます。  
+      前述の仮定に従うと、ファイルのURLはUNCパスに基づいて
+      
+      * `file://fileserver/thinbridge-test/ThinBridgeEdge-v2.3.0.crx`
+      * `file://fileserver/thinbridge-test/ThinBridgeChrome-v2.3.0.crx`
+      
+      となり、ThinBridge拡張機能バージョン2.3.0へ更新する場合の編集後の`manifest.xml`の内容は以下の要領となります。
+      
+      ```xml
+      <?xml version='1.0' encoding='UTF-8'?>
+      <gupdate xmlns='http://www.google.com/update2/response' protocol='2.0'>
+        <app appid='jcamehnjflombcdhafhiogbojgghefec'>
+          <updatecheck
+            codebase='file://fileserver/thinbridge-test/ThinBridgeEdge-v2.3.0.crx'
+            version='2.3.0' />
+        </app>
+        <app appid='XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'>
+          <updatecheck
+            codebase='file://fileserver/thinbridge-test/ThinBridgeChrome-v2.3.0.crx'
+            version='2.3.0' />
+        </app>
+      </gupdate>
+      ```
+   6. 編集後の`manifest.xml`を上書き保存します。
+   7. 1.3で配置した各ファイルおよび`manifest.xml`の「プロパティ」を開き、「セキュリティ」タブを選択して、当該ファイルが「Everyone」で読み取り可能な状態になっていることを確認します。  
+      もしそのようになっていない場合は、以下の手順でファイルを「Everyone」で読み取り可能な状態に設定します。
+      
+      1. 「編集」ボタンをクリックします。
+      2. 開かれたダイアログ内で「追加」ボタンをクリックします。
+      3. 開かれたダイアログ内で「選択するオブジェクト名を入力してください」欄に「Everyone」と入力します。
+      4. 「OK」ボタンを押してダイアログを閉じる操作を3回繰り返します。
+   8. 検証対象の端末に一般ユーザーでログインし、ファイル配布用フォルダー内のファイルを読み取れることを確認します。
+      
+      * `manifest.xml`のURL（前述の仮定に従うと`file://fileserver/thinbridge-test/manifest.xml`）をEdgeで開き、1.5で設定した通りの内容を読み取れることを確認します。
+      * Edge用crxのURL（前述の仮定に従うと`file://fileserver/thinbridge-test/ThinBridgeEdge-v2.3.0.crx`）をEdgeで開き、ファイルがダウンロード可能であることを確認します。
+      * Chrome用crxのURL（前述の仮定に従うと`file://fileserver/thinbridge-test/ThinBridgeChrome-v2.3.0.crx`）をChromeで開き、ファイルがダウンロード可能であることを確認します。
+2. **端末でThinBridge拡張機能が更新されることの確認**  
+   以下の作業はすべて、ADドメイン参加状態の検証対象の端末にて、システム管理者または一般ユーザーが一般ユーザーアカウントで実施します。
+   1. Edgeを起動します。
+   2. Edgeのツールバー上にパズルピース型のボタンをクリックし、「拡張機能の管理」をクリックします。
+   3. 拡張機能の管理画面が開かれますので、「開発者モード」を有効化します。
+   4. 「インストール済の拡張機能」の見出し横に表示される「更新」ボタンをクリックします。
+   5. 読み込み中を示すアニメーションが表示されますので、アニメーションが消えて「拡張機能が更新されました」というメッセージが表示されるまで待ちます。
+   6. 「インストール済の拡張機能」の一覧にある「ThinBridge」の詳細情報を表示し、バージョンが更新後のバージョンと一致していることを確認します。
+   7. 「開発者モード」を無効化します。
+   8. Chromeを起動します。
+   9. Chromeのツールバー上にパズルピース型のボタンをクリックし、「拡張機能の管理」をクリックします。
+   10. 拡張機能の管理画面が開かれますので、「デベロッパー モード」を有効化します。
+   11. ページ上部に表示される「更新」ボタンをクリックします。
+   12. ページ下部に「更新しています...」というメッセージが表示されますので、メッセージが消えるまで待ちます。
+   13. 「すべての拡張機能」の一覧にある「ThinBridge」の詳細情報を表示し、バージョンが更新後のバージョンと一致していることを確認します。
+   14. 「デベロッパー モード」を無効化します。
+
+以上の手順により、組織内サーバーに設置したバージョンのThinBridge拡張機能が、検証対象の端末に反映されます。
+
+
+## 全端末を対象とした更新（本番展開）
+
+ADドメイン参加端末全体を対象として、ThinBridge拡張機能を組織内サーバーで配布する形で新バージョンへ更新する場合について、手順の大まかな流れは以下の通りです。
+
+1. GPOによるThinBridge拡張機能の更新
+2. 端末でThinBridge拡張機能が更新されたことの確認
+
+以下に、具体的な作業手順を記します。
+
+1. **GPOによるThinBridge拡張機能の更新**  
+   組織内サーバーに更新先バージョンのThinBridge拡張機能のファイルを設置します。  
+   以下の作業はすべて、作業環境にて、システム管理者が管理者ユーザーアカウントで実施します。
+   1. ファイル配布サーバー上の全体展開用のファイル配布用フォルダーを開きます。  
+      「ThinBridge拡張機能の組織内サーバーからのインストール」での仮定に従い、コンピューター名/ホスト名が「fileserver」であるWindowsファイル共有サーバーを使用し、ファイル配布用フォルダー名は「thinbridge」を使用するものと仮定します。
+   2. 新バージョンの、組織内配布用の各ブラウザー用crxファイル（`ThinBridgeEdge-vX.X.X.crx`、`ThinBridgeChrome-vX.X.X.crx`）をダウンロードします。  
+      バージョン2.3.0へ更新すると仮定すると、使用するcrxファイルは
+      
+      * `ThinBridgeEdge-v2.3.0.crx`
+      * `ThinBridgeChrome-v2.3.0.crx`
+      
+      となります。
+   3. 新バージョンのcrxファイルを、1.1で開いたファイル配布用フォルダーに設置します。  
+      前述の仮定に従い、各ファイルのUNCパスは
+      
+      * `\\fileserver\thinbridge\ThinBridgeEdge-v2.3.0.crx`
+      * `\\fileserver\thinbridge\ThinBridgeChrome-v2.3.0.crx`
+      
+      となると仮定します。
+   4. ファイル配布用フォルダー内の`manifest.xml`を「メモ帳」もしくは何らかのテキスト編集ツールで開き、ファイルが以下のような内容であることを確認します。
+      
+      ```xml
+      <?xml version='1.0' encoding='UTF-8'?>
+      <gupdate xmlns='http://www.google.com/update2/response' protocol='2.0'>
+        <app appid='jcamehnjflombcdhafhiogbojgghefec'>
+          <updatecheck
+            codebase='（ThinBridgeEdge-vX.X.X.crxのURL）'
+            version='（バージョン番号）' />
+        </app>
+        <app appid='XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'>
+          <updatecheck
+            codebase='（ThinBridgeChrome-vX.X.X.crxのURL）'
+            version='（バージョン番号）' />
+        </app>
+      </gupdate>
+      ```
+   5. 1.4で開いたファイルの`codebase='`から`'`までの間の箇所を、1.3で設置した実際のcrxファイルのURLで置き換えます。  
+      また、`version ='`から`'`までの間の箇所を、更新先のThinBridge拡張機能のバージョンで置き換えます。  
+      前述の仮定に従うと、ファイルのURLはUNCパスに基づいて
+      
+      * `file://fileserver/thinbridge/ThinBridgeEdge-v2.3.0.crx`
+      * `file://fileserver/thinbridge/ThinBridgeChrome-v2.3.0.crx`
+      
+      となり、ThinBridge拡張機能バージョン2.3.0へ更新する場合の編集後の`manifest.xml`の内容は以下の要領となります。
+      
+      ```xml
+      <?xml version='1.0' encoding='UTF-8'?>
+      <gupdate xmlns='http://www.google.com/update2/response' protocol='2.0'>
+        <app appid='jcamehnjflombcdhafhiogbojgghefec'>
+          <updatecheck
+            codebase='file://fileserver/thinbridge/ThinBridgeEdge-v2.3.0.crx'
+            version='2.3.0' />
+        </app>
+        <app appid='XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'>
+          <updatecheck
+            codebase='file://fileserver/thinbridge/ThinBridgeChrome-v2.3.0.crx'
+            version='2.3.0' />
+        </app>
+      </gupdate>
+      ```
+   6. 編集後の`manifest.xml`を上書き保存します。
+   7. 1.3で配置した各ファイルおよび`manifest.xml`の「プロパティ」を開き、「セキュリティ」タブを選択して、当該ファイルが「Everyone」で読み取り可能な状態になっていることを確認します。  
+      もしそのようになっていない場合は、以下の手順でファイルを「Everyone」で読み取り可能な状態に設定します。
+      
+      1. 「編集」ボタンをクリックします。
+      2. 開かれたダイアログ内で「追加」ボタンをクリックします。
+      3. 開かれたダイアログ内で「選択するオブジェクト名を入力してください」欄に「Everyone」と入力します。
+      4. 「OK」ボタンを押してダイアログを閉じる操作を3回繰り返します。
+   8. ADドメイン参加状態の任意の端末に一般ユーザーでログインし、ファイル配布用フォルダー内のファイルを読み取れることを確認します。
+      
+      * `manifest.xml`のURL（前述の仮定に従うと`file://fileserver/thinbridge/manifest.xml`）をEdgeで開き、1.5で設定した通りの内容を読み取れることを確認します。
+      * Edge用crxのURL（前述の仮定に従うと`file://fileserver/thinbridge/ThinBridgeEdge-v2.3.0.crx`）をEdgeで開き、ファイルがダウンロード可能であることを確認します。
+      * Chrome用crxのURL（前述の仮定に従うと`file://fileserver/thinbridge/ThinBridgeChrome-v2.3.0.crx`）をChromeで開き、ファイルがダウンロード可能であることを確認します。
+
+2. **端末でThinBridge拡張機能が更新されることの確認**  
+   以下の作業はすべて、ADドメイン参加状態の検証対象の端末にて、システム管理者または一般ユーザーが一般ユーザーアカウントで実施します。
+   1. Edgeを起動します。
+   2. Edgeのツールバー上にパズルピース型のボタンをクリックし、「拡張機能の管理」をクリックします。
+   3. 拡張機能の管理画面が開かれますので、「開発者モード」を有効化します。
+   4. 「インストール済の拡張機能」の見出し横に表示される「更新」ボタンをクリックします。
+   5. 読み込み中を示すアニメーションが表示されますので、アニメーションが消えて「拡張機能が更新されました」というメッセージが表示されるまで待ちます。
+   6. 「インストール済の拡張機能」の一覧にある「ThinBridge」の詳細情報を表示し、バージョンが更新後のバージョンと一致していることを確認します。
+   7. 「開発者モード」を無効化します。
+   8. Chromeを起動します。
+   9. Chromeのツールバー上にパズルピース型のボタンをクリックし、「拡張機能の管理」をクリックします。
+   10. 拡張機能の管理画面が開かれますので、「デベロッパー モード」を有効化します。
+   11. ページ上部に表示される「更新」ボタンをクリックします。
+   12. ページ下部に「更新しています...」というメッセージが表示されますので、メッセージが消えるまで待ちます。
+   13. 「すべての拡張機能」の一覧にある「ThinBridge」の詳細情報を表示し、バージョンが更新後のバージョンと一致していることを確認します。
+   14. 「デベロッパー モード」を無効化します。
+
+以上の手順により、組織内サーバーに設置したバージョンのThinBridge拡張機能が、各端末に反映されます。
+
+
+
+# ThinBridge拡張機能の組織内サーバーからの切り戻し
+
+## 一部の検証対象端末を対象とした切り戻し（事前検証）
+
+全体展開前の検証のために、ADドメイン参加端末のうち、情報システム部門のみの端末など、一部の端末のみを対象として、ThinBridge拡張機能を組織内サーバーで配布する形で旧バージョンへ切り戻す場合について、手順の大まかな流れは以下の通りです。
+
+1. GPOによるThinBridge拡張機能の切り戻し
+2. 端末でThinBridge拡張機能が切り戻されたことの確認
+
+**ThinBridge拡張機能の組織内サーバーからのインストール時に、事前検証と本番展開で同一のファイル配布用フォルダーを使用していた場合には、以下に記す手順では、検証対象の一部の端末のみを対象として切り戻しを実施することができません。その場合、「ThinBridge拡張機能の組織内サーバーからのインストール」の「一部の検証対象端末を対象としたインストール（事前検証）」に記載の手順に則り、検証対象の端末について、事前検証用のファイル配布用フォルダーに設置した`manifest.xml`およびcrxファイルが使用される状態にあらかじめ変更しておいて下さい。**
+
+以下に、検証対象の端末用に事前検証用のファイル配布用フォルダーが使われている状態を前提として、具体的な作業手順を記します。
+
+1. **ThinBridge拡張機能のファイルの切り戻し**  
+   組織内サーバーに設置したThinBridge拡張機能のファイルを、切り戻し対象のバージョンに差し替えます。  
+   以下の作業はすべて、作業環境にて、システム管理者が管理者ユーザーアカウントで実施します。
+   1. ファイル配布サーバー上の検証対象の端末用のファイル配布用フォルダーを開きます。  
+      「ThinBridge拡張機能の組織内サーバーからのインストール」での仮定に従い、コンピューター名/ホスト名が「fileserver」であるWindowsファイル共有サーバーを使用し、ファイル配布用フォルダー名は「thinbridge-test」を使用するものと仮定します。
+   2. 切り戻し先となる旧バージョンの、組織内配布用の各ブラウザー用crxファイル（`ThinBridgeEdge-vX.X.X.crx`、`ThinBridgeChrome-vX.X.X.crx`）をダウンロードします。  
+      バージョン2.2.1へ切り戻すと仮定すると、使用するcrxファイルは
+      
+      * `ThinBridgeEdge-v2.2.1.crx`
+      * `ThinBridgeChrome-v2.2.1.crx`
+      
+      となります。
+   3. 旧バージョンのcrxファイルを、1.1で開いたファイル配布用フォルダーに設置します。  
+      前述の仮定に従い、各ファイルのUNCパスは
+      
+      * `\\fileserver\thinbridge-test\ThinBridgeEdge-v2.2.1.crx`
+      * `\\fileserver\thinbridge-test\ThinBridgeChrome-v2.2.1.crx`
+      
+      となると仮定します。
+   4. ファイル配布用フォルダー内の`manifest.xml`を「メモ帳」もしくは何らかのテキスト編集ツールで開き、ファイルが以下のような内容であることを確認します。
+      
+      ```xml
+      <?xml version='1.0' encoding='UTF-8'?>
+      <gupdate xmlns='http://www.google.com/update2/response' protocol='2.0'>
+        <app appid='jcamehnjflombcdhafhiogbojgghefec'>
+          <updatecheck
+            codebase='（ThinBridgeEdge-vX.X.X.crxのURL）'
+            version='（バージョン番号）' />
+        </app>
+        <app appid='XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'>
+          <updatecheck
+            codebase='（ThinBridgeChrome-vX.X.X.crxのURL）'
+            version='（バージョン番号）' />
+        </app>
+      </gupdate>
+      ```
+   5. 1.4で開いたファイルの`codebase='`から`'`までの間の箇所を、1.3で設置した実際のcrxファイルのURLで置き換えます。  
+      また、`version ='`から`'`までの間の箇所を、切り戻し先のThinBridge拡張機能のバージョンで置き換えます。  
+      前述の仮定に従うと、ファイルのURLはUNCパスに基づいて
+      
+      * `file://fileserver/thinbridge-test/ThinBridgeEdge-v2.2.1.crx`
+      * `file://fileserver/thinbridge-test/ThinBridgeChrome-v2.2.1.crx`
+      
+      となり、ThinBridge拡張機能バージョン2.2.1へ切り戻す場合の編集後の`manifest.xml`の内容は以下の要領となります。
+      
+      ```xml
+      <?xml version='1.0' encoding='UTF-8'?>
+      <gupdate xmlns='http://www.google.com/update2/response' protocol='2.0'>
+        <app appid='jcamehnjflombcdhafhiogbojgghefec'>
+          <updatecheck
+            codebase='file://fileserver/thinbridge-test/ThinBridgeEdge-v2.2.1.crx'
+            version='2.2.1' />
+        </app>
+        <app appid='XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'>
+          <updatecheck
+            codebase='file://fileserver/thinbridge-test/ThinBridgeChrome-v2.2.1.crx'
+            version='2.2.1' />
+        </app>
+      </gupdate>
+      ```
+   6. 編集後の`manifest.xml`を上書き保存します。
+   7. 1.3で配置した各ファイルおよび`manifest.xml`の「プロパティ」を開き、「セキュリティ」タブを選択して、当該ファイルが「Everyone」で読み取り可能な状態になっていることを確認します。  
+      もしそのようになっていない場合は、以下の手順でファイルを「Everyone」で読み取り可能な状態に設定します。
+      
+      1. 「編集」ボタンをクリックします。
+      2. 開かれたダイアログ内で「追加」ボタンをクリックします。
+      3. 開かれたダイアログ内で「選択するオブジェクト名を入力してください」欄に「Everyone」と入力します。
+      4. 「OK」ボタンを押してダイアログを閉じる操作を3回繰り返します。
+   8. 検証対象の端末に一般ユーザーでログインし、ファイル配布用フォルダー内のファイルを読み取れることを確認します。
+      
+      * `manifest.xml`のURL（前述の仮定に従うと`file://fileserver/thinbridge-test/manifest.xml`）をEdgeで開き、1.5で設定した通りの内容を読み取れることを確認します。
+      * Edge用crxのURL（前述の仮定に従うと`file://fileserver/thinbridge-test/ThinBridgeEdge-v2.2.1.crx`）をEdgeで開き、ファイルがダウンロード可能であることを確認します。
+      * Chrome用crxのURL（前述の仮定に従うと`file://fileserver/thinbridge-test/ThinBridgeChrome-v2.2.1.crx`）をChromeで開き、ファイルがダウンロード可能であることを確認します。
+2. **端末でThinBridge拡張機能が切り戻されることの確認**  
+   以下の作業はすべて、ADドメイン参加状態の検証対象の端末にて、システム管理者または一般ユーザーが一般ユーザーアカウントで実施します。
+   1. Edgeを起動します。
+   2. Edgeのツールバー上にパズルピース型のボタンをクリックし、「拡張機能の管理」をクリックします。
+   3. 拡張機能の管理画面が開かれますので、「開発者モード」を有効化します。
+   4. 「インストール済の拡張機能」の見出し横に表示される「更新」ボタンをクリックします。
+   5. 読み込み中を示すアニメーションが表示されますので、アニメーションが消えて「拡張機能が更新されました」というメッセージが表示されるまで待ちます。
+   6. 「インストール済の拡張機能」の一覧にある「ThinBridge」の詳細情報を表示し、バージョンが切り戻し後のバージョンと一致していることを確認します。
+   7. 「開発者モード」を無効化します。
+   8. Chromeを起動します。
+   9. Chromeのツールバー上にパズルピース型のボタンをクリックし、「拡張機能の管理」をクリックします。
+   10. 拡張機能の管理画面が開かれますので、「デベロッパー モード」を有効化します。
+   11. ページ上部に表示される「更新」ボタンをクリックします。
+   12. ページ下部に「更新しています...」というメッセージが表示されますので、メッセージが消えるまで待ちます。
+   13. 「すべての拡張機能」の一覧にある「ThinBridge」の詳細情報を表示し、バージョンが切り戻し後のバージョンと一致していることを確認します。
+   14. 「デベロッパー モード」を無効化します。
+
+以上の手順により、組織内サーバーに設置したバージョンのThinBridge拡張機能が、検証対象の端末に反映されます。
+
+
+## 全端末を対象とした切り戻し（本番展開）
+
+ADドメイン参加端末全体を対象として、ThinBridge拡張機能を組織内サーバーで配布する形で旧バージョンへ切り戻す場合について、手順の大まかな流れは以下の通りです。
+
+1. GPOによるThinBridge拡張機能の切り戻し
+2. 端末でThinBridge拡張機能が切り戻されたことの確認
+
+以下に、具体的な作業手順を記します。
+
+1. **ThinBridge拡張機能のファイルの切り戻し**  
+   組織内サーバーに設置したThinBridge拡張機能のファイルを切り戻し対象のバージョンへ差し替えます。
+   以下の作業はすべて、作業環境にて、システム管理者が管理者ユーザーアカウントで実施します。
+   1. ファイル配布サーバー上の全体展開用のファイル配布用フォルダーを開きます。  
+      「ThinBridge拡張機能の組織内サーバーからのインストール」での仮定に従い、コンピューター名/ホスト名が「fileserver」であるWindowsファイル共有サーバーを使用し、ファイル配布用フォルダー名は「thinbridge」を使用するものと仮定します。
+   2. 切り戻し先となる旧バージョンの、組織内配布用の各ブラウザー用crxファイル（`ThinBridgeEdge-vX.X.X.crx`、`ThinBridgeChrome-vX.X.X.crx`）をダウンロードします。  
+      バージョン2.2.1へ切り戻すと仮定すると、使用するcrxファイルは
+      
+      * `ThinBridgeEdge-v2.2.1.crx`
+      * `ThinBridgeChrome-v2.2.1.crx`
+      
+      となります。
+   3. 旧バージョンのcrxファイルを、1.1で開いたファイル配布用フォルダーに設置します。  
+      前述の仮定に従い、各ファイルのUNCパスは
+      
+      * `\\fileserver\thinbridge\ThinBridgeEdge-v2.2.1.crx`
+      * `\\fileserver\thinbridge\ThinBridgeChrome-v2.2.1.crx`
+      
+      となると仮定します。
+   4. ファイル配布用フォルダー内の`manifest.xml`を「メモ帳」もしくは何らかのテキスト編集ツールで開き、ファイルが以下のような内容であることを確認します。
+      
+      ```xml
+      <?xml version='1.0' encoding='UTF-8'?>
+      <gupdate xmlns='http://www.google.com/update2/response' protocol='2.0'>
+        <app appid='jcamehnjflombcdhafhiogbojgghefec'>
+          <updatecheck
+            codebase='（ThinBridgeEdge-vX.X.X.crxのURL）'
+            version='（バージョン番号）' />
+        </app>
+        <app appid='XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'>
+          <updatecheck
+            codebase='（ThinBridgeChrome-vX.X.X.crxのURL）'
+            version='（バージョン番号）' />
+        </app>
+      </gupdate>
+      ```
+   5. 1.4で開いたファイルの`codebase='`から`'`までの間の箇所を、1.3で設置した実際のcrxファイルのURLで置き換えます。  
+      また、`version ='`から`'`までの間の箇所を、切り戻し先のThinBridge拡張機能のバージョンで置き換えます。  
+      前述の仮定に従うと、ファイルのURLはUNCパスに基づいて
+      
+      * `file://fileserver/thinbridge/ThinBridgeEdge-v2.2.1.crx`
+      * `file://fileserver/thinbridge/ThinBridgeChrome-v2.2.1.crx`
+      
+      となり、ThinBridge拡張機能バージョン2.2.1へ切り戻す場合の編集後の`manifest.xml`の内容は以下の要領となります。
+      
+      ```xml
+      <?xml version='1.0' encoding='UTF-8'?>
+      <gupdate xmlns='http://www.google.com/update2/response' protocol='2.0'>
+        <app appid='jcamehnjflombcdhafhiogbojgghefec'>
+          <updatecheck
+            codebase='file://fileserver/thinbridge/ThinBridgeEdge-v2.2.1.crx'
+            version='2.2.1' />
+        </app>
+        <app appid='XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'>
+          <updatecheck
+            codebase='file://fileserver/thinbridge/ThinBridgeChrome-v2.2.1.crx'
+            version='2.2.1' />
+        </app>
+      </gupdate>
+      ```
+   6. 編集後の「manifest.xml」を上書き保存します。
+   7. 1.3で配置した各ファイルおよび`manifest.xml`の「プロパティ」を開き、「セキュリティ」タブを選択して、当該ファイルが「Everyone」で読み取り可能な状態になっていることを確認します。  
+      もしそのようになっていない場合は、以下の手順でファイルを「Everyone」で読み取り可能な状態に設定します。
+      
+      1. 「編集」ボタンをクリックします。
+      2. 開かれたダイアログ内で「追加」ボタンをクリックします。
+      3. 開かれたダイアログ内で「選択するオブジェクト名を入力してください」欄に「Everyone」と入力します。
+      4. 「OK」ボタンを押してダイアログを閉じる操作を3回繰り返します。
+   8. ADドメイン参加状態の任意の端末に一般ユーザーでログインし、ファイル配布用フォルダー内のファイルを読み取れることを確認します。
+      
+      * `manifest.xml`のURL（前述の仮定に従うと`file://fileserver/thinbridge/manifest.xml`）をEdgeで開き、1.5で設定した通りの内容を読み取れることを確認します。
+      * Edge用crxのURL（前述の仮定に従うと`file://fileserver/thinbridge/ThinBridgeEdge-v2.2.1.crx`）をEdgeで開き、ファイルがダウンロード可能であることを確認します。
+      * Chrome用crxのURL（前述の仮定に従うと`file://fileserver/thinbridge/ThinBridgeChrome-v2.2.1.crx`）をChromeで開き、ファイルがダウンロード可能であることを確認します。
+2. **端末でThinBridge拡張機能が切り戻されることの確認**  
+   以下の作業はすべて、ADドメイン参加状態の任意の端末にて、システム管理者または一般ユーザーが一般ユーザーアカウントで実施します。
+   1. Edgeを起動します。
+   2. Edgeのツールバー上にパズルピース型のボタンをクリックし、「拡張機能の管理」をクリックします。
+   3. 拡張機能の管理画面が開かれますので、「開発者モード」を有効化します。
+   4. 「インストール済の拡張機能」の見出し横に表示される「更新」ボタンをクリックします。
+   5. 読み込み中を示すアニメーションが表示されますので、アニメーションが消えて「拡張機能が更新されました」というメッセージが表示されるまで待ちます。
+   6. 「インストール済の拡張機能」の一覧にある「ThinBridge」の詳細情報を表示し、バージョンが切り戻し後のバージョンと一致していることを確認します。
+   7. 「開発者モード」を無効化します。
+   8. Chromeを起動します。
+   9. Chromeのツールバー上にパズルピース型のボタンをクリックし、「拡張機能の管理」をクリックします。
+   10. 拡張機能の管理画面が開かれますので、「デベロッパー モード」を有効化します。
+   11. ページ上部に表示される「更新」ボタンをクリックします。
+   12. ページ下部に「更新しています...」というメッセージが表示されますので、メッセージが消えるまで待ちます。
+   13. 「すべての拡張機能」の一覧にある「ThinBridge」の詳細情報を表示し、バージョンが切り戻し後のバージョンと一致していることを確認します。
+   14. 「デベロッパー モード」を無効化します。
+
+以上の手順により、組織内サーバーに設置したバージョンのThinBridge拡張機能が、各端末に反映されます。
+

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,0 +1,10 @@
+
+PANDOC_OPT=--from markdown+autolink_bare_uris --pdf-engine=xelatex --template eisvogel.tex --toc --listings --number-sections
+
+all: InternalDistributionGuide.pdf
+
+%.pdf: %.md eisvogel.tex
+	pandoc $< -o $@ $(PANDOC_OPT)
+
+clean:
+	rm *.pdf

--- a/doc/eisvogel.tex
+++ b/doc/eisvogel.tex
@@ -1,0 +1,1064 @@
+%%
+% Copyright (c) 2017 - 2020, Pascal Wagler;
+% Copyright (c) 2014 - 2020, John MacFarlane
+%
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions
+% are met:
+%
+% - Redistributions of source code must retain the above copyright
+% notice, this list of conditions and the following disclaimer.
+%
+% - Redistributions in binary form must reproduce the above copyright
+% notice, this list of conditions and the following disclaimer in the
+% documentation and/or other materials provided with the distribution.
+%
+% - Neither the name of John MacFarlane nor the names of other
+% contributors may be used to endorse or promote products derived
+% from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+% "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+% LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+% FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+% COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+% INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+% BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+% LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+% CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+% LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+% ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%%
+
+%%
+% This is the Eisvogel pandoc LaTeX template.
+%
+% For usage information and examples visit the official GitHub page:
+% https://github.com/Wandmalfarbe/pandoc-latex-template
+%%
+
+% Options for packages loaded elsewhere
+\PassOptionsToPackage{unicode$for(hyperrefoptions)$,$hyperrefoptions$$endfor$}{hyperref}
+\PassOptionsToPackage{hyphens}{url}
+\PassOptionsToPackage{dvipsnames,svgnames*,x11names*,table}{xcolor}
+$if(dir)$
+$if(latex-dir-rtl)$
+\PassOptionsToPackage{RTLdocument}{bidi}
+$endif$
+$endif$
+$if(CJKmainfont)$
+\PassOptionsToPackage{space}{xeCJK}
+$endif$
+%
+\documentclass[
+$if(fontsize)$
+  $fontsize$,
+$endif$
+$if(lang)$
+  $babel-lang$,
+$endif$
+$if(papersize)$
+  $papersize$paper,
+$else$
+  paper=a4,
+$endif$
+$if(beamer)$
+  ignorenonframetext,
+$if(handout)$
+  handout,
+$endif$
+$if(aspectratio)$
+  aspectratio=$aspectratio$,
+$endif$
+$endif$
+$for(classoption)$
+  $classoption$$sep$,
+$endfor$
+  ,captions=tableheading
+]{$if(beamer)$$documentclass$$else$$if(book)$scrbook$else$scrartcl$endif$$endif$}
+$if(beamer)$
+$if(background-image)$
+\usebackgroundtemplate{%
+  \includegraphics[width=\paperwidth]{$background-image$}%
+}
+$endif$
+\usepackage{pgfpages}
+\setbeamertemplate{caption}[numbered]
+\setbeamertemplate{caption label separator}{: }
+\setbeamercolor{caption name}{fg=normal text.fg}
+\beamertemplatenavigationsymbols$if(navigation)$$navigation$$else$empty$endif$
+$for(beameroption)$
+\setbeameroption{$beameroption$}
+$endfor$
+% Prevent slide breaks in the middle of a paragraph
+\widowpenalties 1 10000
+\raggedbottom
+$if(section-titles)$
+\setbeamertemplate{part page}{
+  \centering
+  \begin{beamercolorbox}[sep=16pt,center]{part title}
+    \usebeamerfont{part title}\insertpart\par
+  \end{beamercolorbox}
+}
+\setbeamertemplate{section page}{
+  \centering
+  \begin{beamercolorbox}[sep=12pt,center]{part title}
+    \usebeamerfont{section title}\insertsection\par
+  \end{beamercolorbox}
+}
+\setbeamertemplate{subsection page}{
+  \centering
+  \begin{beamercolorbox}[sep=8pt,center]{part title}
+    \usebeamerfont{subsection title}\insertsubsection\par
+  \end{beamercolorbox}
+}
+\AtBeginPart{
+  \frame{\partpage}
+}
+\AtBeginSection{
+  \ifbibliography
+  \else
+    \frame{\sectionpage}
+  \fi
+}
+\AtBeginSubsection{
+  \frame{\subsectionpage}
+}
+$endif$
+$endif$
+$if(beamerarticle)$
+\usepackage{beamerarticle} % needs to be loaded first
+$endif$
+\usepackage{amsmath,amssymb}
+$if(fontfamily)$
+\usepackage[$for(fontfamilyoptions)$$fontfamilyoptions$$sep$,$endfor$]{$fontfamily$}
+$else$
+\usepackage{lmodern}
+$endif$
+$if(linestretch)$
+\usepackage{setspace}
+\setstretch{$linestretch$}
+$else$
+\usepackage{setspace}
+\setstretch{1.2}
+$endif$
+\usepackage{amsmath}
+\usepackage{ifxetex,ifluatex}
+\ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
+  \usepackage[$if(fontenc)$$fontenc$$else$T1$endif$]{fontenc}
+  \usepackage[utf8]{inputenc}
+  \usepackage{textcomp} % provide euro and other symbols
+  \usepackage{amssymb}
+\else % if luatex or xetex
+$if(mathspec)$
+  \ifxetex
+    \usepackage{amssymb}
+    \usepackage{mathspec}
+  \else
+    \usepackage{unicode-math}
+  \fi
+$else$
+  \usepackage{unicode-math}
+$endif$
+  \defaultfontfeatures{Scale=MatchLowercase}
+  \defaultfontfeatures[\rmfamily]{Ligatures=TeX,Scale=1}
+$if(mainfont)$
+  \setmainfont[$for(mainfontoptions)$$mainfontoptions$$sep$,$endfor$]{$mainfont$}
+$endif$
+$if(sansfont)$
+  \setsansfont[$for(sansfontoptions)$$sansfontoptions$$sep$,$endfor$]{$sansfont$}
+$endif$
+$if(monofont)$
+  \setmonofont[$for(monofontoptions)$$monofontoptions$$sep$,$endfor$]{$monofont$}
+$endif$
+$for(fontfamilies)$
+  \newfontfamily{$fontfamilies.name$}[$for(fontfamilies.options)$$fontfamilies.options$$sep$,$endfor$]{$fontfamilies.font$}
+$endfor$
+$if(mathfont)$
+$if(mathspec)$
+  \ifxetex
+    \setmathfont(Digits,Latin,Greek)[$for(mathfontoptions)$$mathfontoptions$$sep$,$endfor$]{$mathfont$}
+  \else
+    \setmathfont[$for(mathfontoptions)$$mathfontoptions$$sep$,$endfor$]{$mathfont$}
+  \fi
+$else$
+  \setmathfont[$for(mathfontoptions)$$mathfontoptions$$sep$,$endfor$]{$mathfont$}
+$endif$
+$endif$
+$if(CJKmainfont)$
+  \ifxetex
+    \usepackage{xeCJK}
+    \setCJKmainfont[$for(CJKoptions)$$CJKoptions$$sep$,$endfor$]{$CJKmainfont$}
+  \fi
+$endif$
+$if(luatexjapresetoptions)$
+  \ifluatex
+    \usepackage[$for(luatexjapresetoptions)$$luatexjapresetoptions$$sep$,$endfor$]{luatexja-preset}
+  \fi
+$endif$
+$if(CJKmainfont)$
+  \ifluatex
+    \usepackage[$for(luatexjafontspecoptions)$$luatexjafontspecoptions$$sep$,$endfor$]{luatexja-fontspec}
+    \setmainjfont[$for(CJKoptions)$$CJKoptions$$sep$,$endfor$]{$CJKmainfont$}
+  \fi
+$endif$
+\fi
+$if(beamer)$
+$if(theme)$
+\usetheme[$for(themeoptions)$$themeoptions$$sep$,$endfor$]{$theme$}
+$endif$
+$if(colortheme)$
+\usecolortheme{$colortheme$}
+$endif$
+$if(fonttheme)$
+\usefonttheme{$fonttheme$}
+$endif$
+$if(mainfont)$
+\usefonttheme{serif} % use mainfont rather than sansfont for slide text
+$endif$
+$if(innertheme)$
+\useinnertheme{$innertheme$}
+$endif$
+$if(outertheme)$
+\useoutertheme{$outertheme$}
+$endif$
+$endif$
+% Use upquote if available, for straight quotes in verbatim environments
+\IfFileExists{upquote.sty}{\usepackage{upquote}}{}
+\IfFileExists{microtype.sty}{% use microtype if available
+  \usepackage[$for(microtypeoptions)$$microtypeoptions$$sep$,$endfor$]{microtype}
+  \UseMicrotypeSet[protrusion]{basicmath} % disable protrusion for tt fonts
+}{}
+$if(indent)$
+$else$
+\makeatletter
+\@ifundefined{KOMAClassName}{% if non-KOMA class
+  \IfFileExists{parskip.sty}{%
+    \usepackage{parskip}
+  }{% else
+    \setlength{\parindent}{0pt}
+    \setlength{\parskip}{6pt plus 2pt minus 1pt}}
+}{% if KOMA class
+  \KOMAoptions{parskip=half}}
+\makeatother
+$endif$
+$if(verbatim-in-note)$
+\usepackage{fancyvrb}
+$endif$
+\usepackage{xcolor}
+\definecolor{default-linkcolor}{HTML}{A50000}
+\definecolor{default-filecolor}{HTML}{A50000}
+\definecolor{default-citecolor}{HTML}{4077C0}
+\definecolor{default-urlcolor}{HTML}{4077C0}
+\IfFileExists{xurl.sty}{\usepackage{xurl}}{} % add URL line breaks if available
+$if(footnotes-pretty)$
+% load footmisc in order to customize footnotes (footmisc has to be loaded before hyperref, cf. https://tex.stackexchange.com/a/169124/144087)
+\usepackage[hang,flushmargin,bottom,multiple]{footmisc}
+\setlength{\footnotemargin}{0.8em} % set space between footnote nr and text
+\setlength{\footnotesep}{\baselineskip} % set space between multiple footnotes
+\setlength{\skip\footins}{0.3cm} % set space between page content and footnote
+\setlength{\footskip}{0.9cm} % set space between footnote and page bottom
+$endif$
+\IfFileExists{bookmark.sty}{\usepackage{bookmark}}{\usepackage{hyperref}}
+\hypersetup{
+$if(title-meta)$
+  pdftitle={$title-meta$},
+$endif$
+$if(author-meta)$
+  pdfauthor={$author-meta$},
+$endif$
+$if(lang)$
+  pdflang={$lang$},
+$endif$
+$if(subject)$
+  pdfsubject={$subject$},
+$endif$
+$if(keywords)$
+  pdfkeywords={$for(keywords)$$keywords$$sep$, $endfor$},
+$endif$
+$if(colorlinks)$
+  colorlinks=true,
+  linkcolor=$if(linkcolor)$$linkcolor$$else$default-linkcolor$endif$,
+  filecolor=$if(filecolor)$$filecolor$$else$default-filecolor$endif$,
+  citecolor=$if(citecolor)$$citecolor$$else$default-citecolor$endif$,
+  urlcolor=$if(urlcolor)$$urlcolor$$else$default-urlcolor$endif$,
+$else$
+  hidelinks,
+$endif$
+  breaklinks=true,
+  pdfcreator={LaTeX via pandoc with the Eisvogel template}}
+\urlstyle{same} % disable monospaced font for URLs
+$if(verbatim-in-note)$
+\VerbatimFootnotes % allow verbatim text in footnotes
+$endif$
+$if(geometry)$
+$if(beamer)$
+\geometry{$for(geometry)$$geometry$$sep$,$endfor$}
+$else$
+\usepackage[$for(geometry)$$geometry$$sep$,$endfor$]{geometry}
+$endif$
+$else$
+$if(beamer)$
+$else$
+\usepackage[margin=2.5cm,includehead=true,includefoot=true,centering,$for(geometry)$$geometry$$sep$,$endfor$]{geometry}
+$endif$
+$endif$
+$if(logo)$
+\usepackage[export]{adjustbox}
+\usepackage{graphicx}
+$endif$
+$if(beamer)$
+\newif\ifbibliography
+$endif$
+$if(listings)$
+\usepackage{listings}
+\newcommand{\passthrough}[1]{#1}
+\lstset{defaultdialect=[5.3]Lua}
+\lstset{defaultdialect=[x86masm]Assembler}
+$endif$
+$if(listings-no-page-break)$
+\usepackage{etoolbox}
+\BeforeBeginEnvironment{lstlisting}{\par\noindent\begin{minipage}{\linewidth}}
+\AfterEndEnvironment{lstlisting}{\end{minipage}\par\addvspace{\topskip}}
+$endif$
+$if(lhs)$
+\lstnewenvironment{code}{\lstset{language=Haskell,basicstyle=\small\ttfamily}}{}
+$endif$
+$if(highlighting-macros)$
+$highlighting-macros$
+
+% Workaround/bugfix from jannick0.
+% See https://github.com/jgm/pandoc/issues/4302#issuecomment-360669013)
+% or https://github.com/Wandmalfarbe/pandoc-latex-template/issues/2
+%
+% Redefine the verbatim environment 'Highlighting' to break long lines (with
+% the help of fvextra). Redefinition is necessary because it is unlikely that
+% pandoc includes fvextra in the default template.
+\usepackage{fvextra}
+\DefineVerbatimEnvironment{Highlighting}{Verbatim}{breaklines,fontsize=$if(code-block-font-size)$$code-block-font-size$$else$\small$endif$,commandchars=\\\{\}}
+
+$endif$
+$if(tables)$
+\usepackage{longtable,booktabs,array}
+\usepackage{calc} % for calculating minipage widths
+$if(beamer)$
+\usepackage{caption}
+% Make caption package work with longtable
+\makeatletter
+\def\fnum@table{\tablename~\thetable}
+\makeatother
+$else$
+% Correct order of tables after \paragraph or \subparagraph
+\usepackage{etoolbox}
+\makeatletter
+\patchcmd\longtable{\par}{\if@noskipsec\mbox{}\fi\par}{}{}
+\makeatother
+% Allow footnotes in longtable head/foot
+\IfFileExists{footnotehyper.sty}{\usepackage{footnotehyper}}{\usepackage{footnote}}
+\makesavenoteenv{longtable}
+$endif$
+$endif$
+% add backlinks to footnote references, cf. https://tex.stackexchange.com/questions/302266/make-footnote-clickable-both-ways
+$if(footnotes-disable-backlinks)$
+$else$
+\usepackage{footnotebackref}
+$endif$
+$if(graphics)$
+\usepackage{graphicx}
+\makeatletter
+\def\maxwidth{\ifdim\Gin@nat@width>\linewidth\linewidth\else\Gin@nat@width\fi}
+\def\maxheight{\ifdim\Gin@nat@height>\textheight\textheight\else\Gin@nat@height\fi}
+\makeatother
+% Scale images if necessary, so that they will not overflow the page
+% margins by default, and it is still possible to overwrite the defaults
+% using explicit options in \includegraphics[width, height, ...]{}
+\setkeys{Gin}{width=\maxwidth,height=\maxheight,keepaspectratio}
+% Set default figure placement to htbp
+\makeatletter
+\def\fps@figure{htbp}
+\makeatother
+$endif$
+$if(links-as-notes)$
+% Make links footnotes instead of hotlinks:
+\DeclareRobustCommand{\href}[2]{#2\footnote{\url{#1}}}
+$endif$
+$if(strikeout)$
+\usepackage[normalem]{ulem}
+% Avoid problems with \sout in headers with hyperref
+\pdfstringdefDisableCommands{\renewcommand{\sout}{}}
+$endif$
+\setlength{\emergencystretch}{3em} % prevent overfull lines
+\providecommand{\tightlist}{%
+  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+$if(numbersections)$
+\setcounter{secnumdepth}{$if(secnumdepth)$$secnumdepth$$else$5$endif$}
+$else$
+\setcounter{secnumdepth}{-\maxdimen} % remove section numbering
+$endif$
+$if(beamer)$
+$else$
+$if(block-headings)$
+% Make \paragraph and \subparagraph free-standing
+\ifx\paragraph\undefined\else
+  \let\oldparagraph\paragraph
+  \renewcommand{\paragraph}[1]{\oldparagraph{#1}\mbox{}}
+\fi
+\ifx\subparagraph\undefined\else
+  \let\oldsubparagraph\subparagraph
+  \renewcommand{\subparagraph}[1]{\oldsubparagraph{#1}\mbox{}}
+\fi
+$endif$
+$endif$
+$if(pagestyle)$
+\pagestyle{$pagestyle$}
+$endif$
+
+% Make use of float-package and set default placement for figures to H.
+% The option H means 'PUT IT HERE' (as  opposed to the standard h option which means 'You may put it here if you like').
+\usepackage{float}
+\floatplacement{figure}{$if(float-placement-figure)$$float-placement-figure$$else$H$endif$}
+
+$for(header-includes)$
+$header-includes$
+$endfor$
+$if(lang)$
+\ifxetex
+  $if(mainfont)$
+  $else$
+  % See issue https://github.com/reutenauer/polyglossia/issues/127
+  \renewcommand*\familydefault{\sfdefault}
+  $endif$
+  % Load polyglossia as late as possible: uses bidi with RTL langages (e.g. Hebrew, Arabic)
+  \usepackage{polyglossia}
+  \setmainlanguage[$for(polyglossia-lang.options)$$polyglossia-lang.options$$sep$,$endfor$]{$polyglossia-lang.name$}
+$for(polyglossia-otherlangs)$
+  \setotherlanguage[$for(polyglossia-otherlangs.options)$$polyglossia-otherlangs.options$$sep$,$endfor$]{$polyglossia-otherlangs.name$}
+$endfor$
+\else
+  \usepackage[$for(babel-otherlangs)$$babel-otherlangs$,$endfor$main=$babel-lang$]{babel}
+% get rid of language-specific shorthands (see #6817):
+\let\LanguageShortHands\languageshorthands
+\def\languageshorthands#1{}
+$if(babel-newcommands)$
+  $babel-newcommands$
+$endif$
+\fi
+$endif$
+\ifluatex
+  \usepackage{selnolig}  % disable illegal ligatures
+\fi
+$if(dir)$
+\ifxetex
+  % Load bidi as late as possible as it modifies e.g. graphicx
+  \usepackage{bidi}
+\fi
+\ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
+  \TeXXeTstate=1
+  \newcommand{\RL}[1]{\beginR #1\endR}
+  \newcommand{\LR}[1]{\beginL #1\endL}
+  \newenvironment{RTL}{\beginR}{\endR}
+  \newenvironment{LTR}{\beginL}{\endL}
+\fi
+$endif$
+$if(natbib)$
+\usepackage[$natbiboptions$]{natbib}
+\bibliographystyle{$if(biblio-style)$$biblio-style$$else$plainnat$endif$}
+$endif$
+$if(biblatex)$
+\usepackage[$if(biblio-style)$style=$biblio-style$,$endif$$for(biblatexoptions)$$biblatexoptions$$sep$,$endfor$]{biblatex}
+$for(bibliography)$
+\addbibresource{$bibliography$}
+$endfor$
+$endif$
+$if(csl-refs)$
+\newlength{\cslhangindent}
+\setlength{\cslhangindent}{1.5em}
+\newlength{\csllabelwidth}
+\setlength{\csllabelwidth}{3em}
+\newenvironment{CSLReferences}[2] % #1 hanging-ident, #2 entry spacing
+ {% don't indent paragraphs
+  \setlength{\parindent}{0pt}
+  % turn on hanging indent if param 1 is 1
+  \ifodd #1 \everypar{\setlength{\hangindent}{\cslhangindent}}\ignorespaces\fi
+  % set entry spacing
+  \ifnum #2 > 0
+  \setlength{\parskip}{#2\baselineskip}
+  \fi
+ }%
+ {}
+\usepackage{calc}
+\newcommand{\CSLBlock}[1]{#1\hfill\break}
+\newcommand{\CSLLeftMargin}[1]{\parbox[t]{\csllabelwidth}{#1}}
+\newcommand{\CSLRightInline}[1]{\parbox[t]{\linewidth - \csllabelwidth}{#1}\break}
+\newcommand{\CSLIndent}[1]{\hspace{\cslhangindent}#1}
+$endif$
+
+$if(title)$
+\title{$title$$if(thanks)$\thanks{$thanks$}$endif$}
+$endif$
+$if(subtitle)$
+$if(beamer)$
+$else$
+\usepackage{etoolbox}
+\makeatletter
+\providecommand{\subtitle}[1]{% add subtitle to \maketitle
+  \apptocmd{\@title}{\par {\large #1 \par}}{}{}
+}
+\makeatother
+$endif$
+\subtitle{$subtitle$}
+$endif$
+\author{$for(author)$$author$$sep$ \and $endfor$}
+\date{$date$}
+$if(beamer)$
+$if(institute)$
+\institute{$for(institute)$$institute$$sep$ \and $endfor$}
+$endif$
+$if(titlegraphic)$
+\titlegraphic{\includegraphics{$titlegraphic$}}
+$endif$
+$if(logo)$
+\logo{\includegraphics{$logo$}}
+$endif$
+$endif$
+
+
+
+%%
+%% added
+%%
+
+%
+% language specification
+%
+% If no language is specified, use English as the default main document language.
+%
+$if(lang)$$else$
+\ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
+  \usepackage[shorthands=off,$for(babel-otherlangs)$$babel-otherlangs$,$endfor$main=english]{babel}
+$if(babel-newcommands)$
+  $babel-newcommands$
+$endif$
+\else
+  $if(mainfont)$
+  $else$
+  % Workaround for bug in Polyglossia that breaks `\familydefault` when `\setmainlanguage` is used.
+  % See https://github.com/Wandmalfarbe/pandoc-latex-template/issues/8
+  % See https://github.com/reutenauer/polyglossia/issues/186
+  % See https://github.com/reutenauer/polyglossia/issues/127
+  \renewcommand*\familydefault{\sfdefault}
+  $endif$
+  % load polyglossia as late as possible as it *could* call bidi if RTL lang (e.g. Hebrew or Arabic)
+  \usepackage{polyglossia}
+  \setmainlanguage[]{english}
+$for(polyglossia-otherlangs)$
+  \setotherlanguage[$polyglossia-otherlangs.options$]{$polyglossia-otherlangs.name$}
+$endfor$
+\fi
+$endif$
+
+$if(page-background)$
+\usepackage[pages=all]{background}
+$endif$
+
+%
+% for the background color of the title page
+%
+$if(titlepage)$
+\usepackage{pagecolor}
+\usepackage{afterpage}
+$if(titlepage-background)$
+\usepackage{tikz}
+$endif$
+$if(geometry)$
+$else$
+\usepackage[margin=2.5cm,includehead=true,includefoot=true,centering]{geometry}
+$endif$
+$endif$
+
+%
+% break urls
+%
+\PassOptionsToPackage{hyphens}{url}
+
+%
+% When using babel or polyglossia with biblatex, loading csquotes is recommended
+% to ensure that quoted texts are typeset according to the rules of your main language.
+%
+\usepackage{csquotes}
+
+%
+% captions
+%
+\definecolor{caption-color}{HTML}{777777}
+$if(beamer)$
+$else$
+\usepackage[font={stretch=1.2}, textfont={color=caption-color}, position=top, skip=4mm, labelfont=bf, singlelinecheck=false, justification=$if(caption-justification)$$caption-justification$$else$raggedright$endif$]{caption}
+\setcapindent{0em}
+$endif$
+
+%
+% blockquote
+%
+\definecolor{blockquote-border}{RGB}{221,221,221}
+\definecolor{blockquote-text}{RGB}{119,119,119}
+\usepackage{mdframed}
+\newmdenv[rightline=false,bottomline=false,topline=false,linewidth=3pt,linecolor=blockquote-border,skipabove=\parskip]{customblockquote}
+\renewenvironment{quote}{\begin{customblockquote}\list{}{\rightmargin=0em\leftmargin=0em}%
+\item\relax\color{blockquote-text}\ignorespaces}{\unskip\unskip\endlist\end{customblockquote}}
+
+%
+% Source Sans Pro as the de­fault font fam­ily
+% Source Code Pro for monospace text
+%
+% 'default' option sets the default
+% font family to Source Sans Pro, not \sfdefault.
+%
+\ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
+  $if(fontfamily)$
+  $else$
+  \usepackage[default]{sourcesanspro}
+  \usepackage{sourcecodepro}
+  $endif$
+\else % if not pdftex
+  $if(mainfont)$
+  $else$
+  \usepackage[default]{sourcesanspro}
+  \usepackage{sourcecodepro}
+
+  % XeLaTeX specific adjustments for straight quotes: https://tex.stackexchange.com/a/354887
+  % This issue is already fixed (see https://github.com/silkeh/latex-sourcecodepro/pull/5) but the
+  % fix is still unreleased.
+  % TODO: Remove this workaround when the new version of sourcecodepro is released on CTAN.
+  \ifxetex
+    \makeatletter
+    \defaultfontfeatures[\ttfamily]
+      { Numbers   = \sourcecodepro@figurestyle,
+        Scale     = \SourceCodePro@scale,
+        Extension = .otf }
+    \setmonofont
+      [ UprightFont    = *-\sourcecodepro@regstyle,
+        ItalicFont     = *-\sourcecodepro@regstyle It,
+        BoldFont       = *-\sourcecodepro@boldstyle,
+        BoldItalicFont = *-\sourcecodepro@boldstyle It ]
+      {SourceCodePro}
+    \makeatother
+  \fi
+  $endif$
+\fi
+
+%
+% heading color
+%
+\definecolor{heading-color}{RGB}{40,40,40}
+$if(beamer)$
+$else$
+\addtokomafont{section}{\color{heading-color}}
+$endif$
+% When using the classes report, scrreprt, book,
+% scrbook or memoir, uncomment the following line.
+%\addtokomafont{chapter}{\color{heading-color}}
+
+%
+% variables for title, author and date
+%
+$if(beamer)$
+$else$
+\usepackage{titling}
+\title{$title$}
+\author{$for(author)$$author$$sep$, $endfor$}
+\date{$date$}
+$endif$
+
+%
+% tables
+%
+$if(tables)$
+
+\definecolor{table-row-color}{HTML}{F5F5F5}
+\definecolor{table-rule-color}{HTML}{999999}
+
+%\arrayrulecolor{black!40}
+\arrayrulecolor{table-rule-color}     % color of \toprule, \midrule, \bottomrule
+\setlength\heavyrulewidth{0.3ex}      % thickness of \toprule, \bottomrule
+\renewcommand{\arraystretch}{1.3}     % spacing (padding)
+
+$if(table-use-row-colors)$
+% TODO: This doesn't work anymore. I don't know why.
+% Reset rownum counter so that each table
+% starts with the same row colors.
+% https://tex.stackexchange.com/questions/170637/restarting-rowcolors
+%
+% Unfortunately the colored cells extend beyond the edge of the
+% table because pandoc uses @-expressions (@{}) like so:
+%
+% \begin{longtable}[]{@{}ll@{}}
+% \end{longtable}
+%
+% https://en.wikibooks.org/wiki/LaTeX/Tables#.40-expressions
+\let\oldlongtable\longtable
+\let\endoldlongtable\endlongtable
+\renewenvironment{longtable}{
+\rowcolors{3}{}{table-row-color!100}  % row color
+\oldlongtable} {
+\endoldlongtable
+\global\rownum=0\relax}
+$endif$
+$endif$
+
+%
+% remove paragraph indention
+%
+\setlength{\parindent}{0pt}
+\setlength{\parskip}{6pt plus 2pt minus 1pt}
+\setlength{\emergencystretch}{3em}  % prevent overfull lines
+
+%
+%
+% Listings
+%
+%
+
+$if(listings)$
+
+%
+% general listing colors
+%
+\definecolor{listing-background}{HTML}{F7F7F7}
+\definecolor{listing-rule}{HTML}{B3B2B3}
+\definecolor{listing-numbers}{HTML}{B3B2B3}
+\definecolor{listing-text-color}{HTML}{000000}
+\definecolor{listing-keyword}{HTML}{435489}
+\definecolor{listing-keyword-2}{HTML}{1284CA} % additional keywords
+\definecolor{listing-keyword-3}{HTML}{9137CB} % additional keywords
+\definecolor{listing-identifier}{HTML}{435489}
+\definecolor{listing-string}{HTML}{00999A}
+\definecolor{listing-comment}{HTML}{8E8E8E}
+
+\lstdefinestyle{eisvogel_listing_style}{
+  language         = java,
+$if(listings-disable-line-numbers)$
+  xleftmargin      = 0.6em,
+  framexleftmargin = 0.4em,
+$else$
+  numbers          = left,
+  xleftmargin      = 2.7em,
+  framexleftmargin = 2.5em,
+$endif$
+  backgroundcolor  = \color{listing-background},
+  basicstyle       = \color{listing-text-color}\linespread{1.0}$if(code-block-font-size)$$code-block-font-size$$else$\small$endif$\ttfamily{},
+  breaklines       = true,
+  frame            = single,
+  framesep         = 0.19em,
+  rulecolor        = \color{listing-rule},
+  frameround       = ffff,
+  tabsize          = 4,
+  numberstyle      = \color{listing-numbers},
+  aboveskip        = 1.0em,
+  belowskip        = 0.1em,
+  abovecaptionskip = 0em,
+  belowcaptionskip = 1.0em,
+  keywordstyle     = {\color{listing-keyword}\bfseries},
+  keywordstyle     = {[2]\color{listing-keyword-2}\bfseries},
+  keywordstyle     = {[3]\color{listing-keyword-3}\bfseries\itshape},
+  sensitive        = true,
+  identifierstyle  = \color{listing-identifier},
+  commentstyle     = \color{listing-comment},
+  stringstyle      = \color{listing-string},
+  showstringspaces = false,
+  escapeinside     = {/*@}{@*/}, % Allow LaTeX inside these special comments
+  literate         =
+  {á}{{\'a}}1 {é}{{\'e}}1 {í}{{\'i}}1 {ó}{{\'o}}1 {ú}{{\'u}}1
+  {Á}{{\'A}}1 {É}{{\'E}}1 {Í}{{\'I}}1 {Ó}{{\'O}}1 {Ú}{{\'U}}1
+  {à}{{\`a}}1 {è}{{\'e}}1 {ì}{{\`i}}1 {ò}{{\`o}}1 {ù}{{\`u}}1
+  {À}{{\`A}}1 {È}{{\'E}}1 {Ì}{{\`I}}1 {Ò}{{\`O}}1 {Ù}{{\`U}}1
+  {ä}{{\"a}}1 {ë}{{\"e}}1 {ï}{{\"i}}1 {ö}{{\"o}}1 {ü}{{\"u}}1
+  {Ä}{{\"A}}1 {Ë}{{\"E}}1 {Ï}{{\"I}}1 {Ö}{{\"O}}1 {Ü}{{\"U}}1
+  {â}{{\^a}}1 {ê}{{\^e}}1 {î}{{\^i}}1 {ô}{{\^o}}1 {û}{{\^u}}1
+  {Â}{{\^A}}1 {Ê}{{\^E}}1 {Î}{{\^I}}1 {Ô}{{\^O}}1 {Û}{{\^U}}1
+  {œ}{{\oe}}1 {Œ}{{\OE}}1 {æ}{{\ae}}1 {Æ}{{\AE}}1 {ß}{{\ss}}1
+  {ç}{{\c c}}1 {Ç}{{\c C}}1 {ø}{{\o}}1 {å}{{\r a}}1 {Å}{{\r A}}1
+  {€}{{\EUR}}1 {£}{{\pounds}}1 {«}{{\guillemotleft}}1
+  {»}{{\guillemotright}}1 {ñ}{{\~n}}1 {Ñ}{{\~N}}1 {¿}{{?`}}1
+  {…}{{\ldots}}1 {≥}{{>=}}1 {≤}{{<=}}1 {„}{{\glqq}}1 {“}{{\grqq}}1
+  {”}{{''}}1
+}
+\lstset{style=eisvogel_listing_style}
+
+%
+% Java (Java SE 12, 2019-06-22)
+%
+\lstdefinelanguage{Java}{
+  morekeywords={
+    % normal keywords (without data types)
+    abstract,assert,break,case,catch,class,continue,default,
+    do,else,enum,exports,extends,final,finally,for,if,implements,
+    import,instanceof,interface,module,native,new,package,private,
+    protected,public,requires,return,static,strictfp,super,switch,
+    synchronized,this,throw,throws,transient,try,volatile,while,
+    % var is an identifier
+    var
+  },
+  morekeywords={[2] % data types
+    % primitive data types
+    boolean,byte,char,double,float,int,long,short,
+    % String
+    String,
+    % primitive wrapper types
+    Boolean,Byte,Character,Double,Float,Integer,Long,Short
+    % number types
+    Number,AtomicInteger,AtomicLong,BigDecimal,BigInteger,DoubleAccumulator,DoubleAdder,LongAccumulator,LongAdder,Short,
+    % other
+    Object,Void,void
+  },
+  morekeywords={[3] % literals
+    % reserved words for literal values
+    null,true,false,
+  },
+  sensitive,
+  morecomment  = [l]//,
+  morecomment  = [s]{/*}{*/},
+  morecomment  = [s]{/**}{*/},
+  morestring   = [b]",
+  morestring   = [b]',
+}
+
+\lstdefinelanguage{XML}{
+  morestring      = [b]",
+  moredelim       = [s][\bfseries\color{listing-keyword}]{<}{\ },
+  moredelim       = [s][\bfseries\color{listing-keyword}]{</}{>},
+  moredelim       = [l][\bfseries\color{listing-keyword}]{/>},
+  moredelim       = [l][\bfseries\color{listing-keyword}]{>},
+  morecomment     = [s]{<?}{?>},
+  morecomment     = [s]{<!--}{-->},
+  commentstyle    = \color{listing-comment},
+  stringstyle     = \color{listing-string},
+  identifierstyle = \color{listing-identifier}
+}
+$endif$
+
+%
+% header and footer
+%
+$if(beamer)$
+$else$
+$if(disable-header-and-footer)$
+$else$
+\usepackage{fancyhdr}
+
+\fancypagestyle{eisvogel-header-footer}{
+  \fancyhead{}
+  \fancyfoot{}
+  \lhead[$if(header-right)$$header-right$$else$$date$$endif$]{$if(header-left)$$header-left$$else$$title$$endif$}
+  \chead[$if(header-center)$$header-center$$else$$endif$]{$if(header-center)$$header-center$$else$$endif$}
+  \rhead[$if(header-left)$$header-left$$else$$title$$endif$]{$if(header-right)$$header-right$$else$$date$$endif$}
+  \lfoot[$if(footer-right)$$footer-right$$else$\thepage$endif$]{$if(footer-left)$$footer-left$$else$$for(author)$$author$$sep$, $endfor$$endif$}
+  \cfoot[$if(footer-center)$$footer-center$$else$$endif$]{$if(footer-center)$$footer-center$$else$$endif$}
+  \rfoot[$if(footer-left)$$footer-left$$else$$for(author)$$author$$sep$, $endfor$$endif$]{$if(footer-right)$$footer-right$$else$\thepage$endif$}
+  \renewcommand{\headrulewidth}{0.4pt}
+  \renewcommand{\footrulewidth}{0.4pt}
+}
+\pagestyle{eisvogel-header-footer}
+$if(page-background)$
+\backgroundsetup{
+scale=1,
+color=black,
+opacity=$if(page-background-opacity)$$page-background-opacity$$else$0.2$endif$,
+angle=0,
+contents={%
+  \includegraphics[width=\paperwidth,height=\paperheight]{$page-background$}
+  }%
+}
+$endif$
+$endif$
+$endif$
+
+%%
+%% end added
+%%
+
+\begin{document}
+
+%%
+%% begin titlepage
+%%
+$if(beamer)$
+$else$
+$if(titlepage)$
+\begin{titlepage}
+$if(titlepage-background)$
+\newgeometry{top=2cm, right=4cm, bottom=3cm, left=4cm}
+$else$
+\newgeometry{left=6cm}
+$endif$
+$if(titlepage-color)$
+\definecolor{titlepage-color}{HTML}{$titlepage-color$}
+\newpagecolor{titlepage-color}\afterpage{\restorepagecolor}
+$endif$
+$if(titlepage-background)$
+\tikz[remember picture,overlay] \node[inner sep=0pt] at (current page.center){\includegraphics[width=\paperwidth,height=\paperheight]{$titlepage-background$}};
+$endif$
+\newcommand{\colorRule}[3][black]{\textcolor[HTML]{#1}{\rule{#2}{#3}}}
+\begin{flushleft}
+\noindent
+\\[-1em]
+\color[HTML]{$if(titlepage-text-color)$$titlepage-text-color$$else$5F5F5F$endif$}
+\makebox[0pt][l]{\colorRule[$if(titlepage-rule-color)$$titlepage-rule-color$$else$435488$endif$]{1.3\textwidth}{$if(titlepage-rule-height)$$titlepage-rule-height$$else$4$endif$pt}}
+\par
+\noindent
+
+$if(titlepage-background)$
+% The titlepage with a background image has other text spacing and text size
+{
+  \setstretch{2}
+  \vfill
+  \vskip -8em
+  \noindent {\huge \textbf{\textsf{$title$}}}
+  $if(subtitle)$
+  \vskip 1em
+  {\Large \textsf{$subtitle$}}
+  $endif$
+  \vskip 2em
+  \noindent {\Large \textsf{$for(author)$$author$$sep$, $endfor$} \vskip 0.6em \textsf{$date$}}
+  \vfill
+}
+$else$
+{
+  \setstretch{1.4}
+  \vfill
+  \noindent {\huge \textbf{\textsf{$title$}}}
+  $if(subtitle)$
+  \vskip 1em
+  {\Large \textsf{$subtitle$}}
+  $endif$
+  \vskip 2em
+  \noindent {\Large \textsf{$for(author)$$author$$sep$, $endfor$}}
+  \vfill
+}
+$endif$
+
+$if(logo)$
+\noindent
+\includegraphics[width=$if(logo-width)$$logo-width$$else$100$endif$pt, left]{$logo$}
+$endif$
+
+$if(titlepage-background)$
+$else$
+\textsf{$date$}
+$endif$
+\end{flushleft}
+\end{titlepage}
+\restoregeometry
+$endif$
+$endif$
+
+%%
+%% end titlepage
+%%
+
+$if(has-frontmatter)$
+\frontmatter
+$endif$
+$if(title)$
+$if(beamer)$
+\frame{\titlepage}
+$endif$
+$if(abstract)$
+\begin{abstract}
+$abstract$
+\end{abstract}
+$endif$
+$endif$
+
+$if(first-chapter)$
+\setcounter{chapter}{$first-chapter$}
+\addtocounter{chapter}{-1}
+$endif$
+
+$for(include-before)$
+$include-before$
+
+$endfor$
+$if(toc)$
+$if(toc-title)$
+\renewcommand*\contentsname{$toc-title$}
+$endif$
+$if(beamer)$
+\begin{frame}[allowframebreaks]
+$if(toc-title)$
+  \frametitle{$toc-title$}
+$endif$
+  \tableofcontents[hideallsubsections]
+\end{frame}
+$if(toc-own-page)$
+\newpage
+$endif$
+$else$
+{
+$if(colorlinks)$
+\hypersetup{linkcolor=$if(toccolor)$$toccolor$$else$$endif$}
+$endif$
+\setcounter{tocdepth}{$toc-depth$}
+\tableofcontents
+$if(toc-own-page)$
+\newpage
+$endif$
+}
+$endif$
+$endif$
+$if(lot)$
+\listoftables
+$endif$
+$if(lof)$
+\listoffigures
+$endif$
+$if(linestretch)$
+\setstretch{$linestretch$}
+$endif$
+$if(has-frontmatter)$
+\mainmatter
+$endif$
+$body$
+
+$if(has-frontmatter)$
+\backmatter
+$endif$
+$if(natbib)$
+$if(bibliography)$
+$if(biblio-title)$
+$if(has-chapters)$
+\renewcommand\bibname{$biblio-title$}
+$else$
+\renewcommand\refname{$biblio-title$}
+$endif$
+$endif$
+$if(beamer)$
+\begin{frame}[allowframebreaks]{$biblio-title$}
+  \bibliographytrue
+$endif$
+  \bibliography{$for(bibliography)$$bibliography$$sep$,$endfor$}
+$if(beamer)$
+\end{frame}
+$endif$
+
+$endif$
+$endif$
+$if(biblatex)$
+$if(beamer)$
+\begin{frame}[allowframebreaks]{$biblio-title$}
+  \bibliographytrue
+  \printbibliography[heading=none]
+\end{frame}
+$else$
+\printbibliography$if(biblio-title)$[title=$biblio-title$]$endif$
+$endif$
+
+$endif$
+$for(include-after)$
+$include-after$
+
+$endfor$
+\end{document}

--- a/doc/internal-distribution/chrome.json
+++ b/doc/internal-distribution/chrome.json
@@ -1,0 +1,12 @@
+{
+  "name": "com.clear_code.thinbridge",
+  "description": "ThinBridge Talk Serger",
+  "path": "ThinBridgeTalk.exe",
+  "type": "stdio",
+  "allowed_origins": [
+    "chrome-extension://iiajmhibpjkpmfmbhegccdfmfnfeffmh/",
+    "chrome-extension://knldjmfmopnpolahpmmgbagdohdnhkik/",
+    "chrome-extension://oabjkjegmjblopakfhiboalfnlkhkkem/",
+    "chrome-extension://XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/"
+  ]
+}

--- a/doc/internal-distribution/edge.json
+++ b/doc/internal-distribution/edge.json
@@ -1,0 +1,12 @@
+{
+  "name": "com.clear_code.thinbridge",
+  "description": "ThinBridge Talk Serger",
+  "path": "ThinBridgeTalk.exe",
+  "type": "stdio",
+  "allowed_origins": [
+    "chrome-extension://famoofbkcpjdkihdngnhgbdfkfenhcnf/",
+    "chrome-extension://knldjmfmopnpolahpmmgbagdohdnhkik/",
+    "chrome-extension://loigjahhocfdkpoikniacpfbhailfkfi/",
+    "chrome-extension://jcamehnjflombcdhafhiogbojgghefec/"
+  ]
+}

--- a/doc/internal-distribution/manifest.xml
+++ b/doc/internal-distribution/manifest.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<gupdate xmlns='http://www.google.com/update2/response' protocol='2.0'> 
+  <app appid='jcamehnjflombcdhafhiogbojgghefec'>
+    <updatecheck
+       codebase='file:///C:/path/to/thinbridge/ThinBridgeEdge-v2.2.1.crx'
+       version='2.2.1' /> 
+  </app>
+  <app appid='XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'>
+    <updatecheck
+       codebase='file:///C:/path/to/thinbridge/ThinBridgeChrome-v2.2.1.crx'
+       version='2.2.1' /> 
+  </app>
+</gupdate>


### PR DESCRIPTION

# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

This adds a document to describe how to install Edge and Chrome extensions from internal servers.

# How to verify the fixed issue:

See `doc/InternalDistributionGuide.md` and build a PDF.

## The steps to verify:

1. cd to `doc`
2. Run `make`

## Expected result:

`doc/InternalDistributionGuide.pdf` is built and its contents are readable.
