### PR TITLE
Add a script to update version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,21 +29,24 @@ ThinBridgeはエンタープライズ環境向けのブラウザ切替えソリ�
 ThinBridgeのリリース手順
 ------------------------
 
- 1. ThinBridge.slnをVisual Studio 2019で開き、変更があったモジュールについて、リソースビューから`*.rc`→`Version`→`VS_VERSION_INFO`を開き、`FILEVERSION`および`PRODUCTVERSION`を更新する。
- 2. 変更をcommitする。
- 3. 次のファイルのバージョンをインクリメントする
-    - ThinBridgeSetupX64.iss
-    - ThinBridgeSetupX86.iss
- 4. 次のコマンドでタグを打ってプッシュする
-    ```sh
-    $ make release
+以下、リリースするバージョンを4.2.1.0と仮定して説明する。
+
+ 1. PowerShellウインドウ等を開き、script/ThinBridgeVersionUp.ps1 を使ってインストーラおよび各モジュールのバージョンを更新する
+    ```console
+    > cd script
+    > powershell.exe -ExecutionPolicy Bypass -file .\ThinBridgeVersionUp.ps1 4.2.1.0
     ```
-    または
-    ```sh
-    $ git tag -a v4.0.2.4 -m "ThinBridge v4.0.2.4"
-    $ git push origin master --tags
+ 2. 上記スクリプトによる変更を確認し、問題がなければコミットする。
+    ```console
+    > git diff
+    > git commit -a
     ```
- 5. GitHubリリース上でリリースノートを作成する。
+ 3. 次のコマンドでタグを打ってプッシュする
+    ```console
+    > git tag -a v4.2.1.0 -m "ThinBridge v4.2.1.0"
+    > git push origin master --tags
+    ```
+ 4. GitHubリリース上でリリースノートを作成する。
      * 参考: [現在の最終リリースのリリースノート](https://github.com/ThinBridge/ThinBridge/releases/latest)
      * リリースノートのテンプレート：
        ```
@@ -65,7 +68,7 @@ ThinBridgeのリリース手順
        * **Templates.zip**
          * ThinBridge用のADMXテンプレートです。
        ```
- 6. GitHub Actionsで生成されたEXEインストーラを添付する。
+ 5. GitHub Actionsで生成されたEXEインストーラを添付する。
     [Build ThinBridge](https://github.com/ThinBridge/ThinBridge/actions/workflows/build-release.yaml)のArtifactsから取得した以下のファイルを使用する。
     * `ThinBridgeSetup_x64.exe` （`Installers`から取り出す）
     * `ThinBridgeSetup_x86.exe` （`Installers`から取り出す）

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ ThinBridgeのリリース手順
  1. PowerShellウインドウ等を開き、script/ThinBridgeVersionUp.ps1 を使ってインストーラおよび各モジュールのバージョンを更新する
     ```console
     > cd script
-    > powershell.exe -ExecutionPolicy Bypass -file .\ThinBridgeVersionUp.ps1 4.2.1.0
+    > powershell.exe -ExecutionPolicy RemoteSigned -file .\ThinBridgeVersionUp.ps1 4.2.1.0
     ```
  2. 上記スクリプトによる変更を確認し、問題がなければコミットする。
     ```console

--- a/ThinBridgeX64.iss
+++ b/ThinBridgeX64.iss
@@ -1,4 +1,4 @@
-﻿;ThinBridge Setup--
+;ThinBridge Setup--
 
 [Setup]
 AppName=ThinBridge

--- a/ThinBridgeX86.iss
+++ b/ThinBridgeX86.iss
@@ -1,4 +1,4 @@
-﻿;ThinBridge Setup--
+;ThinBridge Setup--
 
 [Setup]
 AppName=ThinBridge

--- a/script/ThinBridgeVersionUp.HowToUse.md
+++ b/script/ThinBridgeVersionUp.HowToUse.md
@@ -1,0 +1,44 @@
+# ThinBridgeVersionUp の使い方
+
+「ThinBridgeVersionUp」は、ThinBridge のバージョンアップ用スクリプトである
+
+## 機能の概要
+
+- パラメータで指定したバージョン番号`$new_version` の値へ一括更新する
+
+### バージョン情報の付与ルール
+
+- `vx.y.z.b`とする。先頭の「v」に続けて、0 以上の 4 つの整数 x y z b を.（ピリオド）で区切って表記する
+- x,y,z,b の値域はいずれも 0-99（数字 1 桁または 2 桁）とする
+
+## 実行手順
+
+1. エクスプローラー上で`script` フォルダを右クリックして「PowerShell ウィンドウをここで開く」を選択する
+2. PowerShell ウィンドウで下記を実施する
+
+```PowerShell
+~\browserselector\script> powershell.exe -ExecutionPolicy Bypass -file .\ThinBridgeVersionUp.ps1 [$new_version]
+```
+
+- 引数なしで`.\ThinBridgeVersionUp.ps1` を実行した時は、リポジトリ内のバージョン情報の grep 結果を表示する
+- `$new_version` は 0 以上の 4 つの整数 x y z b を .（ピリオド）で区切って指定する（例：`.\ThinBridgeVersionUp.ps1 4.2.1.0`）。「v」は不要
+- 指定した`$new_version` が上記「バージョン情報の付与ルール」に違反している場合、エラーとする
+
+### テストファイルの実行手順
+
+PowerShell のテスティングフレームワーク「[Pester](https://pester.dev/)」にて実行する。手順は次のとおり
+
+1. エクスプローラー上で`script` フォルダを右クリックして「PowerShell ウィンドウをここで開く」を選択する
+2. PowerShell ウィンドウで下記を実施する
+
+```PowerShell
+~\browserselector\script> powershell.exe -ExecutionPolicy Bypass Invoke-Pester
+```
+
+フォルダ内のテストファイル`ThinBridgeVersionUp.Tests.ps1` が実行される
+
+- 上記テストは、`script` 以外のパスから Invoke すると一部"Failed" となる（`script` を基準として更新対象ファイルの存在チェックを行っているため）
+
+### 実行後の注意事項
+
+- 当スクリプトによって変更したファイルのコミットの前に、diff を確認すること

--- a/script/ThinBridgeVersionUp.HowToUse.md
+++ b/script/ThinBridgeVersionUp.HowToUse.md
@@ -17,7 +17,7 @@
 2. PowerShell ウィンドウで下記を実施する
 
 ```PowerShell
-~\browserselector\script> powershell.exe -ExecutionPolicy Bypass -file .\ThinBridgeVersionUp.ps1 [$new_version]
+~\browserselector\script> powershell.exe -ExecutionPolicy RemoteSigned -file .\ThinBridgeVersionUp.ps1 [$new_version]
 ```
 
 - 引数なしで`.\ThinBridgeVersionUp.ps1` を実行した時は、リポジトリ内のバージョン情報の grep 結果を表示する
@@ -32,7 +32,7 @@ PowerShell のテスティングフレームワーク「[Pester](https://pester.
 2. PowerShell ウィンドウで下記を実施する
 
 ```PowerShell
-~\browserselector\script> powershell.exe -ExecutionPolicy Bypass Invoke-Pester
+~\browserselector\script> powershell.exe -ExecutionPolicy RemoteSigned Invoke-Pester
 ```
 
 フォルダ内のテストファイル`ThinBridgeVersionUp.Tests.ps1` が実行される

--- a/script/ThinBridgeVersionUp.Tests.ps1
+++ b/script/ThinBridgeVersionUp.Tests.ps1
@@ -1,0 +1,63 @@
+﻿# Invoke these tests at '\ThinBridge\script' 
+
+Describe "Check if the current version is proper" {
+    Context "Compare the extracted current version to the expected" {
+        BeforeEach {
+            $Env:ThinBridgeVersionUpRootPath = "./fixtures/"
+        }
+        It "Validity of the current version" {
+            # Be sure to update this number according to the version it should be
+            $result = .\ThinBridgeVersionUp.ps1
+            $result | Should Match "9.8.7.6"
+        }
+        AfterEach {
+            $Env:ThinBridgeVersionUpRootPath = ''
+        }
+    }
+}
+
+Describe "Target files to be existent" {
+    Context "For .rc file" {
+        It "Exist ThinBridge.rc" {
+            "../ThinBridge/ThinBridge.rc" | Should Exist
+        } 
+        It "Exist BHORedirector.rc" {
+            "../BHORedirector/BHORedirector.rc" | Should Exist
+        } 
+        It "Exist TBo365URLSync.rc" {
+            "../TBo365URLSync/TBo365URLSync.rc" | Should Exist
+        } 
+        It "Exist TBRedirector.rc" {
+            "../TBRedirector/TBRedirector.rc" | Should Exist
+        } 
+        It "Exist ThinBridgeChecker.rc" {
+            "../ThinBridgeChecker/ThinBridgeChecker.rc" | Should Exist
+        } 
+        It "Exist ThinBridgeRuleUpdater.rc" {
+            "../ThinBridgeRuleUpdater/ThinBridgeRuleUpdater.rc" | Should Exist
+        } 
+        It "Exist ThinBridgeX64.iss" {
+            "../ThinBridgeX64.iss" | Should Exist
+        } 
+        It "Exist ThinBridgeX86.iss" {
+            "../ThinBridgeX86.iss" | Should Exist
+        } 
+    }
+}
+
+Describe "Other ThinBridgeVersionUp tests" {
+    Context "Parameters to fail would include " {
+        It "One that consists of more than 2 digits" {
+            {.\ThinBridgeVersionUp.ps1 -new_version 0.0.100} | Should Throw
+        } 
+        It "Negative number" {
+            {.\ThinBridgeVersionUp -new_version -1.0.0} | Should Throw
+        } 
+        It "Less than 4 numbers in total" {
+            {.\ThinBridgeVersionUp -new_version 9.8.7} | Should Throw
+        } 
+        It "Any invalid separator other than period" {
+            {.\ThinBridgeVersionUp -new_version 1,2,3} | Should Throw
+        } 
+    }
+}

--- a/script/ThinBridgeVersionUp.ps1
+++ b/script/ThinBridgeVersionUp.ps1
@@ -1,0 +1,79 @@
+﻿<#
+	.SYNOPSIS
+		Replace the current version number and GUID of ThinBridge with new ones.
+	.PARAMETER new_version
+		ThinBridgeVersionUp [new_version]
+	.EXAMPLE
+		ThinBridgeVersionUp
+		with no parameter to get the current version
+	.EXAMPLE
+		ThinBridgeVersionUp x.y.z.b
+		update the version number to x.y.z.b
+#>
+# Define parameter
+Param (
+	[ValidatePattern('^\d{1,2}\.\d{1,2}\.\d{1,2}\.\d{1,2}$')]
+	[string]$new_version = 'no_value'
+)
+
+$THIN_BRIDGE_ROOT_PATH = if ([string]::IsNullOrEmpty($Env:ThinBridgeVersionUpRootPath)) { ".." } else { $Env:ThinBridgeVersionUpRootPath }
+
+$TARGET_PATH_ARRAY = ($THIN_BRIDGE_ROOT_PATH + "/ThinBridge/ThinBridge.rc"),
+	($THIN_BRIDGE_ROOT_PATH + "/BHORedirector/BHORedirector.rc"),
+	($THIN_BRIDGE_ROOT_PATH + "/TBo365URLSync/TBo365URLSync.rc"),
+	($THIN_BRIDGE_ROOT_PATH + "/TBRedirector/TBRedirector.rc"),
+	($THIN_BRIDGE_ROOT_PATH + "/ThinBridgeChecker/ThinBridgeChecker.rc"),
+	($THIN_BRIDGE_ROOT_PATH + "/ThinBridgeRuleUpdater/ThinBridgeRuleUpdater.rc"),
+	($THIN_BRIDGE_ROOT_PATH + "/ThinBridgeX64.iss"),
+	($THIN_BRIDGE_ROOT_PATH + "/ThinBridgeX86.iss")
+
+Set-Variable -name VERSION_PATTERN -value '[" ]\d{1,2}[,\.]\d{1,2}[,\.]\d{1,2}[,\.]\d{1,2}' -Option Constant
+Set-Variable -name VERSION_PERIOD -value '\d{1,2}\.\d{1,2}\.\d{1,2}\.\d{1,2}' -Option Constant
+Set-Variable -name VERSION_COMMA -value '\d{1,2},\d{1,2},\d{1,2},\d{1,2}' -Option Constant
+
+# Define Variables
+$new_version_comma = $new_version -Replace '\.',','
+$new_version_plus_quote = $new_version + '"'
+$new_version_plus_period = $new_version + '.'
+
+# 1. function to extract the lines including the version number
+function Extract-current_version() {
+	ForEach ($item in $TARGET_PATH_ARRAY) {
+		Get-Content -Path $item | Select-String -Pattern $VERSION_PATTERN
+	}
+}
+
+# 2. function to update the version number and GUID
+function Update-version_number($new_version) {
+	ForEach ($item in $TARGET_PATH_ARRAY) {
+		$encoding = "Unicode"
+		if (($item -like "*.iss")) {
+			$encoding = "UTF8"
+		}
+		$replaced_content = (Get-Content -Path $item -Encoding $encoding) |
+			ForEach-Object {
+				if ($_ -like "*version*") {
+					$_ -Replace $VERSION_PERIOD, $new_version
+				} else {
+					$_
+				}
+			} |
+			ForEach-Object {
+				if (($_ -like "*version*") -and ($_ -notlike "*IDC_STATIC_VER*")) {
+					$_ -Replace $VERSION_COMMA, $new_version_comma
+				} else {
+					$_
+				}
+			}
+		Set-Content -Path $item -Value $replaced_content -Encoding $encoding
+		# Show the result of replacement on the screen
+		Select-String -Path $item -Pattern $VERSION_PATTERN
+		Write-Host `n
+	}
+}
+
+# Switch what to do depending on the parameter value
+switch ($new_version) {
+	'no_value' {Extract-current_version}
+	Default {Update-version_number $new_version}
+}

--- a/script/fixtures/BHORedirector/BHORedirector.rc
+++ b/script/fixtures/BHORedirector/BHORedirector.rc
@@ -1,0 +1,156 @@
+// Microsoft Visual C++ generated resource script.
+//
+#include "resource.h"
+
+#define APSTUDIO_READONLY_SYMBOLS
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 2 resource.
+//
+#ifndef APSTUDIO_INVOKED
+#include "targetver.h"
+#endif
+#include "winres.h"
+#include "verrsrc.h"
+
+/////////////////////////////////////////////////////////////////////////////
+#undef APSTUDIO_READONLY_SYMBOLS
+
+/////////////////////////////////////////////////////////////////////////////
+// 日本語 (日本) resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_JPN)
+LANGUAGE LANG_JAPANESE, SUBLANG_DEFAULT
+
+#ifdef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE
+//
+
+1 TEXTINCLUDE 
+BEGIN
+    "resource.h\0"
+END
+
+2 TEXTINCLUDE 
+BEGIN
+    "#ifndef APSTUDIO_INVOKED\r\n"
+    "#include ""targetver.h""\r\n"
+    "#endif\r\n"
+    "#include ""winres.h""\r\n"
+    "#include ""verrsrc.h""\r\n"
+    "\0"
+END
+
+3 TEXTINCLUDE 
+BEGIN
+    "1 TYPELIB ""BHORedirector.tlb""\r\n"
+    "\0"
+END
+
+#endif    // APSTUDIO_INVOKED
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Version
+//
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION 9,8,7,6
+ PRODUCTVERSION 9,8,7,6
+ FILEFLAGSMASK 0x3fL
+#ifdef _DEBUG
+ FILEFLAGS 0x1L
+#else
+ FILEFLAGS 0x0L
+#endif
+ FILEOS 0x40004L
+ FILETYPE 0x2L
+ FILESUBTYPE 0x0L
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "041104b0"
+        BEGIN
+            VALUE "CompanyName", "ThinBridge"
+            VALUE "FileDescription", "ThinBridge"
+            VALUE "FileVersion", "9.8.7.6"
+            VALUE "InternalName", "ThinBridgeBHO.dll"
+            VALUE "LegalCopyright", "ThinBridge All rights reserved."
+            VALUE "OriginalFilename", "ThinBridgeBHO.dll"
+            VALUE "ProductName", "ThinBridge Browser Helper"
+            VALUE "ProductVersion", "9.8.7.6"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x411, 1200
+    END
+END
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// REGISTRY
+//
+
+IDR_BHOREDIRECTOR       REGISTRY                "BHORedirector.rgs"
+
+IDR_BHOREDIRECTOR1      REGISTRY                "BHORedirector1.rgs"
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// PNG
+//
+
+IDB_PNG1                PNG                     "RedirectTr.png"
+
+IDB_PNG2                PNG                     "RedirectChrome.png"
+
+IDB_PNG3                PNG                     "RedirectCitrix.png"
+
+IDB_PNG4                PNG                     "RedirectEdge.png"
+
+IDB_PNG5                PNG                     "RedirectFirefox.png"
+
+IDB_PNG6                PNG                     "RedirectRDP.png"
+
+IDB_PNG7                PNG                     "RedirectVMware.png"
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// HTML
+//
+
+IDR_HTML1               HTML                    "html1.htm"
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// String Table
+//
+
+STRINGTABLE
+BEGIN
+    IDS_PROJNAME            "BHORedirector"
+END
+
+#endif    // 日本語 (日本) resources
+/////////////////////////////////////////////////////////////////////////////
+
+
+
+#ifndef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 3 resource.
+//
+1 TYPELIB "BHORedirector.tlb"
+
+/////////////////////////////////////////////////////////////////////////////
+#endif    // not APSTUDIO_INVOKED
+

--- a/script/fixtures/TBRedirector/TBRedirector.rc
+++ b/script/fixtures/TBRedirector/TBRedirector.rc
@@ -1,0 +1,132 @@
+// Microsoft Visual C++ generated resource script.
+//
+#include "resource.h"
+
+#define APSTUDIO_READONLY_SYMBOLS
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 2 resource.
+//
+#ifndef APSTUDIO_INVOKED
+#include "targetver.h"
+#endif
+#include "afxres.h"
+#include "verrsrc.h"
+
+/////////////////////////////////////////////////////////////////////////////
+#undef APSTUDIO_READONLY_SYMBOLS
+
+/////////////////////////////////////////////////////////////////////////////
+// 日本語 (日本) resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_JPN)
+LANGUAGE LANG_JAPANESE, SUBLANG_DEFAULT
+
+#ifdef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE
+//
+
+1 TEXTINCLUDE 
+BEGIN
+    "resource.h\0"
+END
+
+2 TEXTINCLUDE 
+BEGIN
+    "#ifndef APSTUDIO_INVOKED\r\n"
+    "#include ""targetver.h""\r\n"
+    "#endif\r\n"
+    "#include ""afxres.h""\r\n"
+    "#include ""verrsrc.h""\r\n"
+    "\0"
+END
+
+3 TEXTINCLUDE 
+BEGIN
+    "#define _AFX_NO_SPLITTER_RESOURCES\r\n"
+    "#define _AFX_NO_OLE_RESOURCES\r\n"
+    "#define _AFX_NO_TRACKER_RESOURCES\r\n"
+    "#define _AFX_NO_PROPERTY_RESOURCES\r\n"
+    "\r\n"
+    "#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_JPN)\r\n"
+    "LANGUAGE 17, 1\r\n"
+    "#include ""res\\TBRedirector.rc2""  // Microsoft Visual C++ 以外で編集されたリソース\r\n"
+    "#include ""l.JPN\\afxres.rc""      // 標準コンポーネント\r\n"
+    "#endif\r\n"
+    "\0"
+END
+
+#endif    // APSTUDIO_INVOKED
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Icon
+//
+
+// Icon with lowest ID value placed first to ensure application icon
+// remains consistent on all systems.
+IDR_MAINFRAME           ICON                    "res\\TBRedirector.ico"
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Version
+//
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION 9,8,7,6
+ PRODUCTVERSION 9,8,7,6
+ FILEFLAGSMASK 0x3fL
+#ifdef _DEBUG
+ FILEFLAGS 0x1L
+#else
+ FILEFLAGS 0x0L
+#endif
+ FILEOS 0x40004L
+ FILETYPE 0x1L
+ FILESUBTYPE 0x0L
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "041104b0"
+        BEGIN
+            VALUE "FileDescription", "TBRedirector"
+            VALUE "FileVersion", "9.8.7.6"
+            VALUE "InternalName", "TBRedirector.exe"
+            VALUE "OriginalFilename", "TBRedirector.exe"
+            VALUE "ProductVersion", "9.8.7.6"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x411, 1200
+    END
+END
+
+#endif    // 日本語 (日本) resources
+/////////////////////////////////////////////////////////////////////////////
+
+
+
+#ifndef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 3 resource.
+//
+#define _AFX_NO_SPLITTER_RESOURCES
+#define _AFX_NO_OLE_RESOURCES
+#define _AFX_NO_TRACKER_RESOURCES
+#define _AFX_NO_PROPERTY_RESOURCES
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_JPN)
+LANGUAGE 17, 1
+#include "res\TBRedirector.rc2"  // Microsoft Visual C++ 以外で編集されたリソース
+#include "l.JPN\afxres.rc"      // 標準コンポーネント
+#endif
+
+/////////////////////////////////////////////////////////////////////////////
+#endif    // not APSTUDIO_INVOKED
+

--- a/script/fixtures/TBo365URLSync/TBo365URLSync.rc
+++ b/script/fixtures/TBo365URLSync/TBo365URLSync.rc
@@ -1,0 +1,306 @@
+// Microsoft Visual C++ generated resource script.
+//
+#include "resource.h"
+
+#define APSTUDIO_READONLY_SYMBOLS
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 2 resource.
+//
+#ifndef APSTUDIO_INVOKED
+#include "targetver.h"
+#endif
+#include "afxres.h"
+#include "verrsrc.h"
+
+/////////////////////////////////////////////////////////////////////////////
+#undef APSTUDIO_READONLY_SYMBOLS
+
+/////////////////////////////////////////////////////////////////////////////
+// 日本語 (日本) resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_JPN)
+LANGUAGE LANG_JAPANESE, SUBLANG_DEFAULT
+
+#ifdef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE
+//
+
+1 TEXTINCLUDE 
+BEGIN
+    "resource.h\0"
+END
+
+2 TEXTINCLUDE 
+BEGIN
+    "#ifndef APSTUDIO_INVOKED\r\n"
+    "#include ""targetver.h""\r\n"
+    "#endif\r\n"
+    "#include ""afxres.h""\r\n"
+    "#include ""verrsrc.h""\r\n"
+    "\0"
+END
+
+3 TEXTINCLUDE 
+BEGIN
+    "#define _AFX_NO_SPLITTER_RESOURCES\r\n"
+    "#define _AFX_NO_OLE_RESOURCES\r\n"
+    "#define _AFX_NO_TRACKER_RESOURCES\r\n"
+    "#define _AFX_NO_PROPERTY_RESOURCES\r\n"
+    "\r\n"
+    "#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_JPN)\r\n"
+    "LANGUAGE 17, 1\r\n"
+    "#include ""res\\TBo365URLSync.rc2""  // Microsoft Visual C++ 以外で編集されたリソース\r\n"
+    "#include ""l.JPN\\afxres.rc""      // 標準コンポーネント\r\n"
+    "#endif\r\n"
+    "\0"
+END
+
+#endif    // APSTUDIO_INVOKED
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Icon
+//
+
+// Icon with lowest ID value placed first to ensure application icon
+// remains consistent on all systems.
+IDR_MAINFRAME           ICON                    "res\\TBo365URLSync.ico"
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Dialog
+//
+
+IDD_ABOUTBOX DIALOGEX 0, 0, 170, 62
+STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
+CAPTION "バージョン情報 TBo365URLSync"
+FONT 9, "MS UI Gothic", 0, 0, 0x1
+BEGIN
+    ICON            IDR_MAINFRAME,IDC_STATIC,14,14,20,20
+    LTEXT           "TBo365URLSync, Version 1.0",IDC_STATIC,42,14,114,8,SS_NOPREFIX
+    LTEXT           "Copyright (C) 2020",IDC_STATIC,42,26,114,8
+    DEFPUSHBUTTON   "OK",IDOK,113,41,50,14,WS_GROUP
+END
+
+IDD_DLG_MSGBOX DIALOGEX 0, 0, 556, 183
+STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
+CAPTION "詳細メッセージ"
+FONT 10, "ＭＳ ゴシック", 400, 0, 0x80
+BEGIN
+    EDITTEXT        IDC_EDIT1,6,6,542,152,ES_MULTILINE | ES_AUTOVSCROLL | ES_AUTOHSCROLL | ES_WANTRETURN | WS_VSCROLL | WS_HSCROLL
+    PUSHBUTTON      "OK",IDOK,445,162,50,14
+    PUSHBUTTON      "Cancel",IDCANCEL,499,162,50,14
+END
+
+IDD_DLG_RD_EDIT DIALOGEX 0, 0, 406, 57
+STYLE DS_SETFONT | DS_MODALFRAME | DS_FIXEDSYS | WS_POPUP | WS_CAPTION | WS_SYSMENU
+CAPTION "URL"
+FONT 8, "MS Shell Dlg", 400, 0, 0x1
+BEGIN
+    LTEXT           "URL",IDC_STATIC,12,12,18,9
+    EDITTEXT        IDC_EDIT1,31,11,366,12,ES_AUTOHSCROLL
+    DEFPUSHBUTTON   "OK",IDOK,290,35,50,14
+    PUSHBUTTON      "キャンセル",IDCANCEL,347,35,50,14
+END
+
+IDD_DLG_EDIT_URL_ML DIALOGEX 0, 0, 550, 350
+STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
+CAPTION "URLルール編集"
+FONT 10, "ＭＳ ゴシック", 400, 0, 0x80
+BEGIN
+    EDITTEXT        IDC_EDIT1,3,2,544,316,ES_MULTILINE | ES_AUTOVSCROLL | ES_AUTOHSCROLL | ES_WANTRETURN | WS_VSCROLL | WS_HSCROLL
+    PUSHBUTTON      "OK",IDOK,398,325,50,14
+    PUSHBUTTON      "Cancel",IDCANCEL,456,325,50,14
+    LTEXT           "※空白行や先頭の半角スペース/末尾の半角スペースは、自動的に切り詰められます。",IDC_STATIC,7,322,305,19
+    LTEXT           "1行",IDC_STATIC_LINE,509,326,36,12,0,WS_EX_RIGHT | WS_EX_STATICEDGE
+END
+
+IDD_TBo365URLSync_DIALOG DIALOGEX 0, 0, 475, 539
+STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+EXSTYLE WS_EX_APPWINDOW
+CAPTION "ThinBridge Office365"
+FONT 9, "MS UI Gothic", 0, 0, 0x1
+BEGIN
+    ICON            IDR_MAINFRAME,IDC_STATIC,14,14,20,20
+    LTEXT           "Office365 endpoint URL (例 https://endpoints.office.com/endpoints/worldwide?clientrequestid=XXXX",IDC_STATIC,41,11,427,8
+    EDITTEXT        IDC_EDIT1,41,22,427,14,ES_AUTOHSCROLL
+    GROUPBOX        "抽出項目設定",IDC_STATIC,19,47,334,100
+    LTEXT           "ServiceArea (例) Common|Exchange|SharePoint|Skype 空白は全てが対象",IDC_STATIC,24,58,234,8
+    EDITTEXT        IDC_EDIT_AREA,22,69,291,14,ES_AUTOHSCROLL
+    LTEXT           "Category (例) Optimize|Allow|Default 空白は全てが対象",IDC_STATIC,22,84,177,8
+    EDITTEXT        IDC_EDIT_CATEGORY,22,96,291,14,ES_AUTOHSCROLL
+    LTEXT           "Required (例) TRUE/FALSE 空白は全てが対象",IDC_STATIC,22,114,148,8
+    EDITTEXT        IDC_EDIT_REQUIRED,22,125,143,14,ES_AUTOHSCROLL
+    LTEXT           "TcpPort (例) 443|80,443 空白は全てが対象",IDC_STATIC,172,114,138,8
+    EDITTEXT        IDC_EDIT_TCPPORT,172,125,143,14,ES_AUTOHSCROLL
+    PUSHBUTTON      "接続＆取得データ テスト",IDC_BUTTON_TEST,361,51,92,22
+    DEFPUSHBUTTON   "設定のみ保存",IDOK,361,79,92,31
+    PUSHBUTTON      "ThinBridgeBHO.ini更新＆設定保存",IDC_BUTTON_WRITEINI,263,156,136,31
+    PUSHBUTTON      "閉じる",IDCANCEL,403,157,50,31
+    GROUPBOX        "【追加ターゲットURL ルール】",IDC_STATIC,17,195,436,160,WS_GROUP
+    CONTROL         "List1",IDC_LIST1,"SysListView32",LVS_REPORT | LVS_SINGLESEL | LVS_SHOWSELALWAYS | LVS_NOSORTHEADER | WS_BORDER | WS_TABSTOP,20,207,432,129
+    PUSHBUTTON      "新規登録",IDC_BUTTON_INS,18,338,38,14
+    PUSHBUTTON      "編集",IDC_BUTTON_UPDATE,57,338,38,14
+    PUSHBUTTON      "削除",IDC_BUTTON_DEL,96,338,38,14
+    PUSHBUTTON      "一括登録・編集",IDC_BUTTON_EDITALL,135,338,50,14
+    PUSHBUTTON      "↑",IDC_BUTTON_UP,188,338,12,14,BS_PUSHLIKE
+    PUSHBUTTON      "↓",IDC_BUTTON_DOWN,202,338,12,14,BS_PUSHLIKE
+    RTEXT           "0件",IDC_STATIC_CNT,423,340,26,8
+    GROUPBOX        "【追加除外URL ルール】",IDC_STATIC2,17,361,438,162,WS_GROUP
+    CONTROL         "",IDC_LIST2,"SysListView32",LVS_REPORT | LVS_SINGLESEL | LVS_SHOWSELALWAYS | LVS_NOSORTHEADER | WS_BORDER | WS_TABSTOP,20,371,432,129
+    PUSHBUTTON      "新規登録",IDC_BUTTON_INS2,18,505,38,14
+    PUSHBUTTON      "編集",IDC_BUTTON_UPDATE2,57,505,38,14
+    PUSHBUTTON      "削除",IDC_BUTTON_DEL2,96,505,38,14
+    PUSHBUTTON      "一括登録・編集",IDC_BUTTON_EDITALL2,135,505,50,14
+    PUSHBUTTON      "↑",IDC_BUTTON_UP2,188,505,12,14
+    PUSHBUTTON      "↓",IDC_BUTTON_DOWN2,202,505,12,14
+    RTEXT           "0件",IDC_STATIC_CNT2,423,505,26,8
+END
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Version
+//
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION 9,8,7,6
+ PRODUCTVERSION 9,8,7,6
+ FILEFLAGSMASK 0x3fL
+#ifdef _DEBUG
+ FILEFLAGS 0x1L
+#else
+ FILEFLAGS 0x0L
+#endif
+ FILEOS 0x40004L
+ FILETYPE 0x1L
+ FILESUBTYPE 0x0L
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "041104b0"
+        BEGIN
+            VALUE "CompanyName", "ThinBridge"
+            VALUE "FileDescription", "TBo365URLSync"
+            VALUE "FileVersion", "9.8.7.6"
+            VALUE "InternalName", "TBo365URLSync.exe"
+            VALUE "LegalCopyright", "ThinBridge"
+            VALUE "OriginalFilename", "TBo365URLSync.exe"
+            VALUE "ProductName", "TBo365URLSync"
+            VALUE "ProductVersion", "9.8.7.6"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x411, 1200
+    END
+END
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// DESIGNINFO
+//
+
+#ifdef APSTUDIO_INVOKED
+GUIDELINES DESIGNINFO
+BEGIN
+    IDD_ABOUTBOX, DIALOG
+    BEGIN
+        LEFTMARGIN, 7
+        RIGHTMARGIN, 163
+        TOPMARGIN, 7
+        BOTTOMMARGIN, 55
+    END
+
+    IDD_DLG_MSGBOX, DIALOG
+    BEGIN
+    END
+
+    IDD_DLG_RD_EDIT, DIALOG
+    BEGIN
+    END
+
+    IDD_DLG_EDIT_URL_ML, DIALOG
+    BEGIN
+    END
+
+    IDD_TBo365URLSync_DIALOG, DIALOG
+    BEGIN
+        LEFTMARGIN, 7
+        RIGHTMARGIN, 468
+        TOPMARGIN, 7
+        BOTTOMMARGIN, 532
+    END
+END
+#endif    // APSTUDIO_INVOKED
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// AFX_DIALOG_LAYOUT
+//
+
+IDD_ABOUTBOX AFX_DIALOG_LAYOUT
+BEGIN
+    0
+END
+
+IDD_DLG_MSGBOX AFX_DIALOG_LAYOUT
+BEGIN
+    0
+END
+
+IDD_TBo365URLSync_DIALOG AFX_DIALOG_LAYOUT
+BEGIN
+    0
+END
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Bitmap
+//
+
+IDB_BITMAP1             BITMAP                  "res\\bitmap1.bmp"
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// String Table
+//
+
+STRINGTABLE
+BEGIN
+    IDS_ABOUTBOX            "バージョン情報 TBo365URLSync(&A)..."
+END
+
+#endif    // 日本語 (日本) resources
+/////////////////////////////////////////////////////////////////////////////
+
+
+
+#ifndef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 3 resource.
+//
+#define _AFX_NO_SPLITTER_RESOURCES
+#define _AFX_NO_OLE_RESOURCES
+#define _AFX_NO_TRACKER_RESOURCES
+#define _AFX_NO_PROPERTY_RESOURCES
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_JPN)
+LANGUAGE 17, 1
+#include "res\TBo365URLSync.rc2"  // Microsoft Visual C++ 以外で編集されたリソース
+#include "l.JPN\afxres.rc"      // 標準コンポーネント
+#endif
+
+/////////////////////////////////////////////////////////////////////////////
+#endif    // not APSTUDIO_INVOKED
+

--- a/script/fixtures/ThinBridge/ThinBridge.rc
+++ b/script/fixtures/ThinBridge/ThinBridge.rc
@@ -1,0 +1,693 @@
+// Microsoft Visual C++ generated resource script.
+//
+#include "resource.h"
+
+#define APSTUDIO_READONLY_SYMBOLS
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 2 resource.
+//
+#ifndef APSTUDIO_INVOKED
+#include "targetver.h"
+#endif
+#include "afxres.h"
+#include "verrsrc.h"
+
+/////////////////////////////////////////////////////////////////////////////
+#undef APSTUDIO_READONLY_SYMBOLS
+
+/////////////////////////////////////////////////////////////////////////////
+// 日本語 (日本) resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_JPN)
+LANGUAGE LANG_JAPANESE, SUBLANG_DEFAULT
+
+#ifdef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE
+//
+
+1 TEXTINCLUDE 
+BEGIN
+    "resource.h\0"
+END
+
+2 TEXTINCLUDE 
+BEGIN
+    "#ifndef APSTUDIO_INVOKED\r\n"
+    "#include ""targetver.h""\r\n"
+    "#endif\r\n"
+    "#include ""afxres.h""\r\n"
+    "#include ""verrsrc.h""\r\n"
+    "\0"
+END
+
+3 TEXTINCLUDE 
+BEGIN
+    "#define _AFX_NO_SPLITTER_RESOURCES\r\n"
+    "#define _AFX_NO_OLE_RESOURCES\r\n"
+    "#define _AFX_NO_TRACKER_RESOURCES\r\n"
+    "#define _AFX_NO_PROPERTY_RESOURCES\r\n"
+    "\r\n"
+    "#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_JPN)\r\n"
+    "LANGUAGE 17, 1\r\n"
+    "#include ""res\\ThinBridge.rc2""  // Microsoft Visual C++ 以外で編集されたリソース\r\n"
+    "#include ""l.JPN\\afxres.rc""      // 標準コンポーネント\r\n"
+    "#endif\r\n"
+    "\0"
+END
+
+#endif    // APSTUDIO_INVOKED
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Icon
+//
+
+// Icon with lowest ID value placed first to ensure application icon
+// remains consistent on all systems.
+IDR_MAINFRAME           ICON                    "res\\ThinBridge.ico"
+
+IDI_ICON_Chrome         ICON                    "res\\chrome.ico"
+
+IDI_ICON_Ctrix          ICON                    "res\\ctx.ico"
+
+IDI_ICON_Edge           ICON                    "res\\edge.ico"
+
+IDI_ICON_Firefox        ICON                    "res\\firefox.ico"
+
+IDI_ICON_IE             ICON                    "res\\ie.ico"
+
+IDI_ICON_RDP            ICON                    "res\\rdp.ico"
+
+IDI_ICON_VMH            ICON                    "res\\vmh.ico"
+
+IDI_ICON_o365           ICON                    "res\\o365.ico"
+
+IDI_ICON_DMZ            ICON                    "res\\DMZ.ico"
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Dialog
+//
+
+IDD_DIALOG1 DIALOGEX 0, 0, 306, 58
+STYLE DS_SETFONT | DS_MODALFRAME | DS_FIXEDSYS | DS_CENTER | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+EXSTYLE WS_EX_TOPMOST
+CAPTION "ThinBridge"
+FONT 8, "MS Shell Dlg", 400, 0, 0x1
+BEGIN
+    LTEXT           "アプリケーションを起動しています。　しばらくお待ち下さい。",IDC_STATIC,9,9,191,8
+    CONTROL         "",IDC_PROGRESS1,"msctls_progress32",PBS_MARQUEE | WS_BORDER,38,23,248,15
+    CONTROL         "",IDC_STATIC_MSG,"Static",SS_LEFTNOWORDWRAP | WS_GROUP,6,43,296,8
+    ICON            "",IDC_STATIC_IMAGE,9,21,20,20,SS_CENTERIMAGE
+END
+
+IDD_DIALOG2 DIALOGEX 0, 0, 406, 67
+STYLE DS_SETFONT | DS_MODALFRAME | DS_FIXEDSYS | WS_POPUP | WS_CAPTION | WS_SYSMENU
+CAPTION "URL"
+FONT 8, "MS Shell Dlg", 400, 0, 0x1
+BEGIN
+    LTEXT           "URL",IDC_STATIC,12,27,18,9
+    EDITTEXT        IDC_EDIT1,31,26,366,12,ES_AUTOHSCROLL
+    DEFPUSHBUTTON   "OK",IDOK,290,46,50,14
+    PUSHBUTTON      "キャンセル",IDCANCEL,346,46,50,14
+    LTEXT           "動作確認用URLを入力します。 ブラウザーからのリダイレクト時は、自動的にURLが引き継がれます。",IDC_STATIC,12,9,326,8
+END
+
+IDD_DIALOG3 DIALOGEX 0, 0, 379, 344
+STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
+CAPTION "詳細設定パラメータ編集"
+FONT 10, "ＭＳ ゴシック", 400, 0, 0x80
+BEGIN
+    EDITTEXT        IDC_EDIT1,6,6,366,312,ES_MULTILINE | ES_AUTOVSCROLL | ES_AUTOHSCROLL | ES_WANTRETURN | WS_VSCROLL | WS_HSCROLL
+    PUSHBUTTON      "保存",IDOK,270,325,50,14
+    PUSHBUTTON      "閉じる",IDCANCEL,324,325,50,14
+END
+
+IDD_DLG_SETTING DIALOGEX 0, 0, 575, 460
+STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
+CAPTION "Settings"
+FONT 9, "MS UI Gothic", 0, 0, 0x1
+BEGIN
+    CONTROL         "Tree1",IDC_TREE_CTRL,"SysTreeView32",TVS_HASBUTTONS | TVS_HASLINES | TVS_DISABLEDRAGDROP | TVS_SHOWSELALWAYS | WS_BORDER | WS_HSCROLL | WS_TABSTOP,3,3,118,417
+    CONTROL         "",IDC_PAGE_FRAME,"Static",SS_GRAYFRAME,124,25,446,395
+    DEFPUSHBUTTON   "設定保存",IDOK,412,428,75,25
+    PUSHBUTTON      "閉じる",IDCANCEL,495,428,75,25
+    LTEXT           "",IDC_CAPTION_BAR,124,4,446,17,SS_CENTERIMAGE
+    LTEXT           "スタティック",IDC_STATIC_PCNAME,3,429,118,12,0,WS_EX_STATICEDGE
+END
+
+IDD_DLG_RDP DIALOGEX 0, 0, 441, 390
+STYLE DS_SETFONT | DS_CONTROL | WS_CHILD | WS_CAPTION
+CAPTION "Dialog"
+FONT 9, "MS UI Gothic", 0, 0, 0x1
+BEGIN
+    GROUPBOX        "【Microsoft】 Remote Desktop Service(MS-RDP) 設定",IDC_STATIC,7,7,430,375
+    LTEXT           "接続先サーバー",IDC_STATIC,18,58,48,8
+    LTEXT           "<サーバー名 または IPアドレス>:<ポート番号> 例)rdshost.local:3389",IDC_STATIC,74,45,217,8
+    EDITTEXT        IDC_EDIT1,74,56,223,12,ES_AUTOHSCROLL
+    GROUPBOX        "表示モード",IDC_STATIC,17,75,280,26
+    CONTROL         "RemoteApp(公開アプリケーション)",IDC_RADIO1,"Button",BS_AUTORADIOBUTTON,23,86,115,10
+    CONTROL         "RemoteDesktop(公開デスクトップ)",IDC_RADIO2,"Button",BS_AUTORADIOBUTTON,155,86,119,10
+    GROUPBOX        "リモートアプリ設定",IDC_STATIC,17,109,280,114
+    LTEXT           "アプリ名",IDC_STATIC,23,126,26,8
+    EDITTEXT        IDC_EDIT2,54,124,238,12,ES_AUTOHSCROLL
+    LTEXT           "アプリのフルパス",IDC_STATIC,23,144,45,8
+    EDITTEXT        IDC_EDIT3,24,155,269,12,ES_AUTOHSCROLL
+    LTEXT           "追加用 コマンド引数",IDC_STATIC,23,173,63,8
+    EDITTEXT        IDC_EDIT4,24,185,269,13,ES_AUTOHSCROLL
+    PUSHBUTTON      "IE設定値セット",IDC_BUTTON_IE,24,203,59,13
+    PUSHBUTTON      "Firefox設定値セット",IDC_BUTTON_FF,84,203,75,13
+    PUSHBUTTON      "Chrome設定値セット",IDC_BUTTON_GC,160,203,75,13
+    PUSHBUTTON      "設定値クリア",IDC_BUTTON_CLR,236,203,57,13
+    GROUPBOX        "ローカル デバイスとリソース設定",IDC_STATIC,17,231,280,43
+    CONTROL         "クリップボードのリダイレクトを許可する",IDC_CHECK1,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,24,244,133,9
+    CONTROL         "プリンターのリダイレクトを許可する",IDC_CHECK2,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,171,244,123,9
+    CONTROL         "ディスク・ドライブのリダイレクトを許可する",IDC_CHECK3,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,24,261,143,9
+    PUSHBUTTON      "接続テスト(MS-RDP)...",IDC_BUTTON1,17,286,89,13
+    PUSHBUTTON      "RDP接続 - 詳細設定パラメータ編集....",IDC_BUTTON_ST,155,286,143,13
+    ICON            "",IDC_STATIC_IMAGE,16,24,20,20,SS_CENTERIMAGE
+END
+
+IDD_DLG_VMW DIALOGEX 0, 0, 441, 390
+STYLE DS_SETFONT | DS_CONTROL | WS_CHILD | WS_CAPTION
+CAPTION "Dialog"
+FONT 9, "MS UI Gothic", 0, 0, 0x1
+BEGIN
+    GROUPBOX        "【VMware】 Horizon(Horizon RDSH / VDI) 設定",IDC_STATIC,7,7,430,375
+    LTEXT           "Connectionサーバー",IDC_STATIC,12,58,63,8
+    LTEXT           "BrokerHostname Connection Server名",IDC_STATIC,77,43,112,8
+    EDITTEXT        IDC_EDIT_VHOST,77,56,204,12,ES_AUTOHSCROLL
+    LTEXT           "アプリ名",IDC_STATIC,46,98,24,8
+    LTEXT           "RDSH アプリケーション名(表示名) / VDI プール名(表示名)",IDC_STATIC,77,85,176,8
+    EDITTEXT        IDC_EDIT_VAPP,77,96,204,12,ES_AUTOHSCROLL
+    PUSHBUTTON      "接続テスト(VMware Horizon)...",IDC_BUTTON_TEST_V,18,137,112,14
+    ICON            "",IDC_STATIC_IMAGE,16,24,20,20,SS_CENTERIMAGE
+END
+
+IDD_DLG_ETC DIALOGEX 0, 0, 441, 390
+STYLE DS_SETFONT | DS_CONTROL | WS_CHILD | WS_CAPTION
+CAPTION "Dialog"
+FONT 9, "MS UI Gothic", 0, 0, 0x1
+BEGIN
+    GROUPBOX        "全般設定",IDC_STATIC,9,7,430,380
+    ICON            IDR_MAINFRAME,IDC_STATIC,311,25,20,20
+    LTEXT           "ThinBridge Version 9.8.7.6",IDC_STATIC_VER,339,32,89,8,SS_NOPREFIX
+    GROUPBOX        "【重要】URLマッチングルール全体設定",IDC_STATIC,14,49,381,94
+    CONTROL         "クイック判定機能を有効にする (※IE専用機能)",IDC_CHK_GLOVAL_QUICK,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,18,64,156,10
+    LTEXT           "注意：\nナビゲーション前イベントを優先的に利用しリダイレクトを高速化します。\nリダイレクト通知画面は表示されません。",IDC_STATIC,18,77,372,32,0,WS_EX_STATICEDGE
+    CONTROL         "URL部分のみ基準とし判定する　(Getパラメータ部分を無視する #  ? 以降のURLStringを判断しない)",IDC_CHK_GLOVAL_URL_ONLY,
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,18,115,360,10
+    CONTROL         "アドレスバーに表示されるURLのみを判定する",IDC_CHK_GLOVAL_TOP_PAGE_ONLY,
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,18,128,360,10
+    CONTROL         "Internet Explorer (ローカル)を開く時に別ウィンドウを表示する (タブを追加しない) ",IDC_CHK_GLOVAL_DISABLE_DDE,
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,18,160,256,10
+    GROUPBOX        "TRACE Log (※IE専用機能)",IDC_STATIC,14,198,381,107
+    CONTROL         "TRACE Logを出力する",IDC_CHK_GLOVAL_TRACE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,18,213,80,10
+    PUSHBUTTON      "TRACE Log モニター ウインドウを開く...",IDC_BUTTON1,17,228,117,23
+    LTEXT           "注意：\nTRACE Logを出力する場合は、Internet Explorerの保護モードを無効にし再スタートする必要があります。\n\n[インターネット オプション]-[セキュリティ]タブ-[保護モードを有効にする(Internet Explorerの再起動が必要)]のチェックをOFF",IDC_STATIC,18,258,372,39,0,WS_EX_STATICEDGE
+END
+
+IDD_DLG_RD_RDP DIALOGEX 0, 0, 441, 390
+STYLE DS_SETFONT | DS_CONTROL | WS_CHILD | WS_CAPTION
+CAPTION "Dialog"
+FONT 9, "MS UI Gothic", 0, 0, 0x1
+BEGIN
+    CONTROL         "無効にする",IDC_CHECK_DISABLE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,5,46,10
+    ICON            "",IDC_STATIC_IMAGE,8,19,20,20,SS_CENTERIMAGE
+    GROUPBOX        "※IEからのリダイレクト時に表示される通知画面設定",IDC_STATIC_IEG,52,3,387,32
+    LTEXT           "リダイレクトページ動作設定",IDC_STATIC_TY,56,22,81,8
+    COMBOBOX        IDC_COMBO1,139,19,228,12,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+    LTEXT           "表示秒数",IDC_STATIC_SEC,372,12,31,8
+    EDITTEXT        IDC_EDIT1,408,10,25,14,ES_RIGHT | ES_AUTOHSCROLL | ES_NUMBER
+    LTEXT           "(1 - 60秒)",IDC_STATIC_SEC2,404,25,35,8
+    GROUPBOX        "【ターゲットURL ルール】",IDC_STATIC,2,48,438,174,WS_GROUP
+    CONTROL         "List1",IDC_LIST1,"SysListView32",LVS_REPORT | LVS_SINGLESEL | LVS_SHOWSELALWAYS | LVS_NOSORTHEADER | WS_BORDER | WS_TABSTOP,5,61,432,140
+    PUSHBUTTON      "新規登録",IDC_BUTTON_INS,3,203,38,14
+    PUSHBUTTON      "編集",IDC_BUTTON_UPDATE,42,203,38,14
+    PUSHBUTTON      "削除",IDC_BUTTON_DEL,81,203,38,14
+    PUSHBUTTON      "一括登録・編集",IDC_BUTTON_EDITALL,120,203,50,14
+    PUSHBUTTON      "↑",IDC_BUTTON_UP,173,203,12,14,BS_PUSHLIKE
+    PUSHBUTTON      "↓",IDC_BUTTON_DOWN,187,203,12,14,BS_PUSHLIKE
+    RTEXT           "0件",IDC_STATIC_CNT,408,205,26,8
+    GROUPBOX        "【除外URL ルール】",IDC_STATIC2,2,225,438,162,WS_GROUP
+    CONTROL         "",IDC_LIST2,"SysListView32",LVS_REPORT | LVS_SINGLESEL | LVS_SHOWSELALWAYS | LVS_NOSORTHEADER | WS_BORDER | WS_TABSTOP,5,236,432,129
+    PUSHBUTTON      "新規登録",IDC_BUTTON_INS2,3,369,38,14
+    PUSHBUTTON      "編集",IDC_BUTTON_UPDATE2,42,369,38,14
+    PUSHBUTTON      "削除",IDC_BUTTON_DEL2,81,369,38,14
+    PUSHBUTTON      "一括登録・編集",IDC_BUTTON_EDITALL2,120,369,50,14
+    PUSHBUTTON      "↑",IDC_BUTTON_UP2,173,369,12,14
+    PUSHBUTTON      "↓",IDC_BUTTON_DOWN2,187,369,12,14
+    RTEXT           "0件",IDC_STATIC_CNT2,408,370,26,8
+END
+
+IDD_DLG_RD_CUSTOM DIALOGEX 0, 0, 441, 390
+STYLE DS_SETFONT | DS_CONTROL | WS_CHILD | WS_CAPTION
+CAPTION "Dialog"
+FONT 9, "MS UI Gothic", 0, 0, 0x1
+BEGIN
+    CONTROL         "無効にする",IDC_CHECK_DISABLE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,5,46,10
+    ICON            "",IDC_STATIC_IMAGE,8,19,20,20,SS_CENTERIMAGE
+    GROUPBOX        "※IEからのリダイレクト時に表示される通知画面設定",IDC_STATIC,52,3,387,32
+    LTEXT           "リダイレクトページ動作設定",IDC_STATIC,57,22,81,8
+    COMBOBOX        IDC_COMBO1,139,19,228,12,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+    LTEXT           "表示秒数",IDC_STATIC,372,12,31,8
+    EDITTEXT        IDC_EDIT1,408,10,25,14,ES_RIGHT | ES_AUTOHSCROLL | ES_NUMBER
+    LTEXT           "(1 - 60秒)",IDC_STATIC,404,25,35,8
+    LTEXT           "ブラウザーパス",IDC_STATIC,58,38,43,8
+    EDITTEXT        IDC_EDIT_LCB,106,36,230,13,ES_AUTOHSCROLL
+    PUSHBUTTON      "参照...",IDC_BUTTON_FDLG,340,36,37,13
+    GROUPBOX        "【ターゲットURL ルール】",IDC_STATIC,2,48,436,173,WS_GROUP
+    CONTROL         "List1",IDC_LIST1,"SysListView32",LVS_REPORT | LVS_SINGLESEL | LVS_SHOWSELALWAYS | LVS_NOSORTHEADER | WS_BORDER | WS_TABSTOP,5,61,432,140
+    PUSHBUTTON      "新規登録",IDC_BUTTON_INS,3,203,38,14
+    PUSHBUTTON      "編集",IDC_BUTTON_UPDATE,42,203,38,14
+    PUSHBUTTON      "削除",IDC_BUTTON_DEL,81,203,38,14
+    PUSHBUTTON      "一括登録・編集",IDC_BUTTON_EDITALL,120,203,50,14
+    PUSHBUTTON      "↑",IDC_BUTTON_UP,173,203,12,14,BS_PUSHLIKE
+    PUSHBUTTON      "↓",IDC_BUTTON_DOWN,187,203,12,14,BS_PUSHLIKE
+    RTEXT           "0件",IDC_STATIC_CNT,408,205,26,8
+    GROUPBOX        "【除外URL ルール】",IDC_STATIC2,2,225,438,162,WS_GROUP
+    CONTROL         "",IDC_LIST2,"SysListView32",LVS_REPORT | LVS_SINGLESEL | LVS_SHOWSELALWAYS | LVS_NOSORTHEADER | WS_BORDER | WS_TABSTOP,5,236,432,129
+    PUSHBUTTON      "新規登録",IDC_BUTTON_INS2,3,369,38,14
+    PUSHBUTTON      "編集",IDC_BUTTON_UPDATE2,42,369,38,14
+    PUSHBUTTON      "削除",IDC_BUTTON_DEL2,81,369,38,14
+    PUSHBUTTON      "一括登録・編集",IDC_BUTTON_EDITALL2,120,369,50,14
+    PUSHBUTTON      "↑",IDC_BUTTON_UP2,173,369,12,14
+    PUSHBUTTON      "↓",IDC_BUTTON_DOWN2,187,369,12,14
+    RTEXT           "0件",IDC_STATIC_CNT2,408,370,26,8
+END
+
+IDD_DLG_RD_O365 DIALOGEX 0, 0, 441, 390
+STYLE DS_SETFONT | DS_CONTROL | WS_CHILD | WS_CAPTION
+CAPTION "Dialog"
+FONT 9, "MS UI Gothic", 0, 0, 0x1
+BEGIN
+    CONTROL         "無効にする",IDC_CHECK_DISABLE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,5,46,10
+    ICON            "",IDC_STATIC_IMAGE,8,19,20,20,SS_CENTERIMAGE
+    GROUPBOX        "※IEからのリダイレクト時に表示される通知画面設定",IDC_STATIC,52,3,387,32
+    LTEXT           "リダイレクトページ動作設定",IDC_STATIC,57,22,81,8
+    COMBOBOX        IDC_COMBO1,139,19,228,12,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+    LTEXT           "表示秒数",IDC_STATIC,372,12,31,8
+    EDITTEXT        IDC_EDIT1,408,10,25,14,ES_RIGHT | ES_AUTOHSCROLL | ES_NUMBER
+    LTEXT           "(1 - 60秒)",IDC_STATIC,404,25,35,8
+    LTEXT           "ブラウザー種別",IDC_STATIC,57,38,43,8
+    COMBOBOX        IDC_COMBO2,106,36,230,30,CBS_DROPDOWN | WS_VSCROLL | WS_TABSTOP
+    PUSHBUTTON      "参照...",IDC_BUTTON_FDLG,340,36,37,13
+    LTEXT           "※Office365設定は、ThinBridge Office365設定から行います。",IDC_STATIC,8,58,192,8
+    PUSHBUTTON      "ThinBridge Office365設定起動...",IDC_BUTTON_O365,247,56,124,14
+    PUSHBUTTON      "ルール再読込み",IDC_BUTTON_O365_RELOAD,379,56,55,14
+    GROUPBOX        "【ターゲットURL ルール】",IDC_STATIC,2,71,436,161,WS_GROUP
+    CONTROL         "List1",IDC_LIST1,"SysListView32",LVS_REPORT | LVS_SINGLESEL | LVS_SHOWSELALWAYS | LVS_NOSORTHEADER | WS_BORDER | WS_TABSTOP,5,84,432,129
+    RTEXT           "0件",IDC_STATIC_CNT,408,217,26,8
+    GROUPBOX        "【除外URL ルール】",IDC_STATIC2,2,238,438,149,WS_GROUP
+    CONTROL         "",IDC_LIST2,"SysListView32",LVS_REPORT | LVS_SINGLESEL | LVS_SHOWSELALWAYS | LVS_NOSORTHEADER | WS_BORDER | WS_TABSTOP,5,247,432,118
+    RTEXT           "0件",IDC_STATIC_CNT2,408,370,26,8
+    LTEXT           "※自動更新のため、参照専用",IDC_STATIC,6,219,144,8
+    LTEXT           "※自動更新のため、参照専用",IDC_STATIC,9,372,144,8
+    PUSHBUTTON      "クリップボードにコピー",IDC_BUTTON1,335,216,66,11
+    PUSHBUTTON      "クリップボードにコピー",IDC_BUTTON2,335,368,66,11
+END
+
+IDD_DLG_RD_Default DIALOGEX 0, 0, 441, 390
+STYLE DS_SETFONT | DS_CONTROL | WS_CHILD | WS_CAPTION
+CAPTION "Dialog"
+FONT 9, "MS UI Gothic", 0, 0, 0x1
+BEGIN
+    LTEXT           "ブラウザー種別",IDC_STATIC,9,38,43,8
+    COMBOBOX        IDC_COMBO2,58,36,230,30,CBS_DROPDOWN | WS_VSCROLL | WS_TABSTOP
+    PUSHBUTTON      "参照...",IDC_BUTTON_FDLG,292,36,37,13
+    LTEXT           "※その他(未定義)URLの場合に表示するブラウザーを設定します。",IDC_STATIC,8,17,194,8
+END
+
+IDD_DLG_RD_EDIT DIALOGEX 0, 0, 406, 57
+STYLE DS_SETFONT | DS_MODALFRAME | DS_FIXEDSYS | WS_POPUP | WS_CAPTION | WS_SYSMENU
+CAPTION "URL"
+FONT 8, "MS Shell Dlg", 400, 0, 0x1
+BEGIN
+    LTEXT           "URL",IDC_STATIC,12,12,18,9
+    EDITTEXT        IDC_EDIT1,31,11,366,12,ES_AUTOHSCROLL
+    DEFPUSHBUTTON   "OK",IDOK,290,35,50,14
+    PUSHBUTTON      "キャンセル",IDCANCEL,347,35,50,14
+    CONTROL         "有効にする",IDC_CHECK1,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,12,36,51,10
+    LTEXT           "※先頭が - # ; から始まるURLは設定できません。",IDC_STATIC,78,36,178,8
+END
+
+IDD_DLG_EDIT_URL_ML DIALOGEX 0, 0, 550, 350
+STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
+CAPTION "URLルール編集"
+FONT 10, "ＭＳ ゴシック", 400, 0, 0x80
+BEGIN
+    EDITTEXT        IDC_EDIT1,3,2,544,316,ES_MULTILINE | ES_AUTOVSCROLL | ES_AUTOHSCROLL | ES_WANTRETURN | WS_VSCROLL | WS_HSCROLL
+    PUSHBUTTON      "OK",IDOK,398,325,50,14
+    PUSHBUTTON      "Cancel",IDCANCEL,456,325,50,14
+    LTEXT           "※先頭に'#'または';'を記述すると、その行は無効化(コメントアウト)されます。\n空白行や先頭の半角スペース/末尾の半角スペースは、自動的に切り詰められます。",IDC_STATIC,7,322,305,19
+    LTEXT           "1行",IDC_STATIC_LINE,509,326,36,12,0,WS_EX_RIGHT | WS_EX_STATICEDGE
+END
+
+IDD_DLG_MSGBOX DIALOGEX 0, 0, 379, 183
+STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
+CAPTION "詳細メッセージ"
+FONT 10, "ＭＳ ゴシック", 400, 0, 0x80
+BEGIN
+    EDITTEXT        IDC_EDIT1,6,6,366,152,ES_MULTILINE | ES_AUTOVSCROLL | ES_AUTOHSCROLL | ES_WANTRETURN | WS_VSCROLL | WS_HSCROLL
+    PUSHBUTTON      "OK",IDOK,270,162,50,14
+    PUSHBUTTON      "Cancel",IDCANCEL,324,162,50,14
+END
+
+IDD_DLG_CX DIALOGEX 0, 0, 441, 390
+STYLE DS_SETFONT | DS_CONTROL | WS_CHILD | WS_CAPTION
+CAPTION "Dialog"
+FONT 9, "MS UI Gothic", 0, 0, 0x1
+BEGIN
+    GROUPBOX        "【Citrix】 Virtual Apps/XenApp 設定",-1,7,7,430,375
+    LTEXT           "アプリ名",IDC_STATIC_CX3,23,59,24,8
+    LTEXT           "アプリケーション名(表示名)",IDC_STATIC_CX2,50,44,79,8
+    EDITTEXT        IDC_EDIT_CXAPP,49,57,204,12,ES_AUTOHSCROLL
+    PUSHBUTTON      "接続テスト(Citrix Virtual Apps/XenApp)...",IDC_BUTTON_TEST_CX,19,99,159,14
+    ICON            "",IDC_STATIC_IMAGE,16,24,20,20,SS_CENTERIMAGE
+END
+
+IDD_DLG_DEBUG_WND DIALOGEX 0, 0, 630, 380
+STYLE DS_SETFONT | WS_MINIMIZEBOX | WS_MAXIMIZEBOX | WS_POPUP | WS_CAPTION | WS_SYSMENU | WS_THICKFRAME
+CAPTION "TRACE Log Monitor  Window"
+FONT 10, "ＭＳ ゴシック", 400, 0, 0x80
+BEGIN
+    EDITTEXT        IDC_EDIT1,3,25,622,354,ES_MULTILINE | ES_AUTOVSCROLL | ES_AUTOHSCROLL | ES_WANTRETURN | WS_VSCROLL | WS_HSCROLL
+    PUSHBUTTON      "クリップボードにコピー",IDC_BUTTON1,5,5,93,14
+    PUSHBUTTON      "表示クリア",IDOK,103,5,50,14
+    PUSHBUTTON      "閉じる",IDCANCEL,155,5,50,14
+    LTEXT           "1行",IDC_STATIC_LINE,210,6,42,12,0,WS_EX_RIGHT | WS_EX_STATICEDGE
+END
+
+IDD_DLG_RD_CH_SWITCH DIALOGEX 0, 0, 441, 390
+STYLE DS_SETFONT | DS_CONTROL | WS_CHILD | WS_CAPTION
+CAPTION "Dialog"
+FONT 9, "MS UI Gothic", 0, 0, 0x1
+BEGIN
+    CONTROL         "無効にする",IDC_CHECK_DISABLE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,5,46,10
+    ICON            "",IDC_STATIC_IMAGE,8,19,20,20,SS_CENTERIMAGE
+    GROUPBOX        "※IEからのリダイレクト時に表示される通知画面設定",IDC_STATIC,52,3,387,32
+    LTEXT           "リダイレクトページ動作設定",IDC_STATIC,57,22,81,8
+    COMBOBOX        IDC_COMBO1,139,19,228,12,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+    LTEXT           "表示秒数",IDC_STATIC,372,12,31,8
+    EDITTEXT        IDC_EDIT1,408,10,25,14,ES_RIGHT | ES_AUTOHSCROLL | ES_NUMBER
+    LTEXT           "(1 - 60秒)",IDC_STATIC,404,25,35,8
+    LTEXT           "ブラウザーパス",IDC_STATIC,58,38,43,8
+    EDITTEXT        IDC_EDIT_LCB,106,36,230,13,ES_AUTOHSCROLL
+    PUSHBUTTON      "参照...",IDC_BUTTON_FDLG,340,36,37,13
+    LTEXT           "※Chrome自動切換え設定は、ThinBridge ChromeSwitcher設定から行います。",IDC_STATIC,8,58,242,8
+    PUSHBUTTON      "ThinBridge ChromeSwitcher設定起動...",IDC_BUTTON_CSW,254,56,149,14
+    GROUPBOX        "【ターゲットURL ルール】",IDC_STATIC,2,72,436,148,WS_GROUP
+    CONTROL         "List1",IDC_LIST1,"SysListView32",LVS_REPORT | LVS_SINGLESEL | LVS_SHOWSELALWAYS | LVS_NOSORTHEADER | WS_BORDER | WS_TABSTOP,5,84,432,117
+    PUSHBUTTON      "新規登録",IDC_BUTTON_INS,3,203,38,14
+    PUSHBUTTON      "編集",IDC_BUTTON_UPDATE,42,203,38,14
+    PUSHBUTTON      "削除",IDC_BUTTON_DEL,81,203,38,14
+    PUSHBUTTON      "一括登録・編集",IDC_BUTTON_EDITALL,120,203,50,14
+    PUSHBUTTON      "↑",IDC_BUTTON_UP,173,203,12,14,BS_PUSHLIKE
+    PUSHBUTTON      "↓",IDC_BUTTON_DOWN,187,203,12,14,BS_PUSHLIKE
+    RTEXT           "0件",IDC_STATIC_CNT,408,205,26,8
+    GROUPBOX        "【除外URL ルール】",IDC_STATIC2,2,225,438,162,WS_GROUP
+    CONTROL         "",IDC_LIST2,"SysListView32",LVS_REPORT | LVS_SINGLESEL | LVS_SHOWSELALWAYS | LVS_NOSORTHEADER | WS_BORDER | WS_TABSTOP,5,236,432,129
+    PUSHBUTTON      "新規登録",IDC_BUTTON_INS2,3,369,38,14
+    PUSHBUTTON      "編集",IDC_BUTTON_UPDATE2,42,369,38,14
+    PUSHBUTTON      "削除",IDC_BUTTON_DEL2,81,369,38,14
+    PUSHBUTTON      "一括登録・編集",IDC_BUTTON_EDITALL2,120,369,50,14
+    PUSHBUTTON      "↑",IDC_BUTTON_UP2,173,369,12,14
+    PUSHBUTTON      "↓",IDC_BUTTON_DOWN2,187,369,12,14
+    RTEXT           "0件",IDC_STATIC_CNT2,408,370,26,8
+END
+
+IDD_DLG_RD_DMZ DIALOGEX 0, 0, 441, 390
+STYLE DS_SETFONT | DS_CONTROL | WS_CHILD | WS_CAPTION
+CAPTION "Dialog"
+FONT 9, "MS UI Gothic", 0, 0, 0x1
+BEGIN
+    CONTROL         "無効にする",IDC_CHECK_DISABLE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,5,46,10
+    ICON            "",IDC_STATIC_IMAGE,8,19,20,20,SS_CENTERIMAGE
+    LTEXT           "※※IEやChrome等でリダイレクトを行わない(対象外)にしたいURLを設定します。※※\n\n使用例：\n　　　　　シングルサインオン(SSO)やSAML認証を利用したシステム等でIEとChrome等のブラウザー両方で\n　　　　　同じURLを経由する場合に共用URLを設定します。\n\n　　　　　※共用URLを設定しない場合は、IEかChrome等の何れか一方にリダイレクトされます。",-1,63,6,357,62
+    GROUPBOX        "【共用URL ルール】IE、Chrome等で表示するURL（リダイレクトしない物）",-1,2,72,436,315,WS_GROUP
+    CONTROL         "List1",IDC_LIST1,"SysListView32",LVS_REPORT | LVS_SINGLESEL | LVS_SHOWSELALWAYS | LVS_NOSORTHEADER | WS_BORDER | WS_TABSTOP,5,84,432,276
+    PUSHBUTTON      "新規登録",IDC_BUTTON_INS,3,369,38,14
+    PUSHBUTTON      "編集",IDC_BUTTON_UPDATE,42,369,38,14
+    PUSHBUTTON      "削除",IDC_BUTTON_DEL,81,369,38,14
+    PUSHBUTTON      "一括登録・編集",IDC_BUTTON_EDITALL,120,369,50,14
+    PUSHBUTTON      "↑",IDC_BUTTON_UP,173,369,12,14,BS_PUSHLIKE
+    PUSHBUTTON      "↓",IDC_BUTTON_DOWN,187,369,12,14,BS_PUSHLIKE
+    RTEXT           "0件",IDC_STATIC_CNT,408,371,26,8
+END
+
+IDD_DLG_REMOTE DIALOGEX 0, 0, 370, 291
+STYLE DS_SETFONT | DS_CONTROL | WS_CHILD | WS_CAPTION
+CAPTION "Dialog"
+FONT 9, "MS UI Gothic", 0, 0, 0x1
+BEGIN
+    LTEXT           "リモート転送 設定",IDC_STATIC,7,11,347,257
+END
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Version
+//
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION 9,8,7,6
+ PRODUCTVERSION 9,8,7,6
+ FILEFLAGSMASK 0x3fL
+#ifdef _DEBUG
+ FILEFLAGS 0x1L
+#else
+ FILEFLAGS 0x0L
+#endif
+ FILEOS 0x40004L
+ FILETYPE 0x1L
+ FILESUBTYPE 0x0L
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "041104b0"
+        BEGIN
+            VALUE "FileDescription", "ThinBridgeX-Point"
+            VALUE "FileVersion", "9.8.7.6"
+            VALUE "InternalName", "ThinBridge.exe"
+            VALUE "OriginalFilename", "ThinBridge.exe"
+            VALUE "ProductVersion", "9.8.7.6"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x411, 1200
+    END
+END
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// DESIGNINFO
+//
+
+#ifdef APSTUDIO_INVOKED
+GUIDELINES DESIGNINFO
+BEGIN
+    IDD_DIALOG1, DIALOG
+    BEGIN
+        BOTTOMMARGIN, 54
+    END
+
+    IDD_DIALOG2, DIALOG
+    BEGIN
+        LEFTMARGIN, 7
+        RIGHTMARGIN, 399
+        TOPMARGIN, 7
+        BOTTOMMARGIN, 60
+    END
+
+    IDD_DIALOG3, DIALOG
+    BEGIN
+        LEFTMARGIN, 7
+        RIGHTMARGIN, 372
+        TOPMARGIN, 7
+        BOTTOMMARGIN, 337
+    END
+
+    IDD_DLG_SETTING, DIALOG
+    BEGIN
+        RIGHTMARGIN, 570
+    END
+
+    IDD_DLG_RDP, DIALOG
+    BEGIN
+        LEFTMARGIN, 7
+        RIGHTMARGIN, 440
+        TOPMARGIN, 7
+        BOTTOMMARGIN, 372
+    END
+
+    IDD_DLG_VMW, DIALOG
+    BEGIN
+        RIGHTMARGIN, 370
+        BOTTOMMARGIN, 291
+    END
+
+    IDD_DLG_ETC, DIALOG
+    BEGIN
+        RIGHTMARGIN, 439
+        BOTTOMMARGIN, 387
+    END
+
+    IDD_DLG_RD_RDP, DIALOG
+    BEGIN
+        RIGHTMARGIN, 440
+        BOTTOMMARGIN, 386
+    END
+
+    IDD_DLG_RD_CUSTOM, DIALOG
+    BEGIN
+        RIGHTMARGIN, 371
+        BOTTOMMARGIN, 352
+    END
+
+    IDD_DLG_RD_O365, DIALOG
+    BEGIN
+    END
+
+    IDD_DLG_RD_Default, DIALOG
+    BEGIN
+    END
+
+    IDD_DLG_RD_EDIT, DIALOG
+    BEGIN
+        LEFTMARGIN, 7
+        RIGHTMARGIN, 397
+        TOPMARGIN, 7
+        BOTTOMMARGIN, 50
+    END
+
+    IDD_DLG_EDIT_URL_ML, DIALOG
+    BEGIN
+        LEFTMARGIN, 2
+        BOTTOMMARGIN, 343
+    END
+
+    IDD_DLG_MSGBOX, DIALOG
+    BEGIN
+        LEFTMARGIN, 7
+        RIGHTMARGIN, 372
+        TOPMARGIN, 7
+        BOTTOMMARGIN, 176
+    END
+
+    IDD_DLG_CX, DIALOG
+    BEGIN
+        RIGHTMARGIN, 370
+        BOTTOMMARGIN, 291
+    END
+
+    IDD_DLG_DEBUG_WND, DIALOG
+    BEGIN
+        LEFTMARGIN, 2
+        RIGHTMARGIN, 625
+        BOTTOMMARGIN, 373
+    END
+
+    IDD_DLG_RD_CH_SWITCH, DIALOG
+    BEGIN
+        BOTTOMMARGIN, 352
+    END
+
+    IDD_DLG_RD_DMZ, DIALOG
+    BEGIN
+        BOTTOMMARGIN, 387
+    END
+
+    IDD_DLG_REMOTE, DIALOG
+    BEGIN
+    END
+END
+#endif    // APSTUDIO_INVOKED
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// AFX_DIALOG_LAYOUT
+//
+
+IDD_DLG_ETC AFX_DIALOG_LAYOUT
+BEGIN
+    0
+END
+
+IDD_DLG_RD_CH_SWITCH AFX_DIALOG_LAYOUT
+BEGIN
+    0
+END
+
+IDD_DLG_RD_DMZ AFX_DIALOG_LAYOUT
+BEGIN
+    0
+END
+
+IDD_DLG_CX AFX_DIALOG_LAYOUT
+BEGIN
+    0
+END
+
+IDD_DLG_RD_CUSTOM AFX_DIALOG_LAYOUT
+BEGIN
+    0
+END
+
+IDD_DLG_RD_RDP AFX_DIALOG_LAYOUT
+BEGIN
+    0
+END
+
+IDD_DLG_RD_O365 AFX_DIALOG_LAYOUT
+BEGIN
+    0
+END
+
+IDD_DLG_RD_Default AFX_DIALOG_LAYOUT
+BEGIN
+    0
+END
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// String Table
+//
+
+STRINGTABLE
+BEGIN
+    IDS_ABOUTBOX            "バージョン情報 (&A)..."
+END
+
+#endif    // 日本語 (日本) resources
+/////////////////////////////////////////////////////////////////////////////
+
+
+
+#ifndef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 3 resource.
+//
+#define _AFX_NO_SPLITTER_RESOURCES
+#define _AFX_NO_OLE_RESOURCES
+#define _AFX_NO_TRACKER_RESOURCES
+#define _AFX_NO_PROPERTY_RESOURCES
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_JPN)
+LANGUAGE 17, 1
+#include "res\ThinBridge.rc2"  // Microsoft Visual C++ 以外で編集されたリソース
+#include "l.JPN\afxres.rc"      // 標準コンポーネント
+#endif
+
+/////////////////////////////////////////////////////////////////////////////
+#endif    // not APSTUDIO_INVOKED
+

--- a/script/fixtures/ThinBridgeChecker/ThinBridgeChecker.rc
+++ b/script/fixtures/ThinBridgeChecker/ThinBridgeChecker.rc
@@ -1,0 +1,241 @@
+// Microsoft Visual C++ generated resource script.
+//
+#include "resource.h"
+
+#define APSTUDIO_READONLY_SYMBOLS
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 2 resource.
+//
+#ifndef APSTUDIO_INVOKED
+#include "targetver.h"
+#endif
+#include "afxres.h"
+#include "verrsrc.h"
+
+/////////////////////////////////////////////////////////////////////////////
+#undef APSTUDIO_READONLY_SYMBOLS
+
+/////////////////////////////////////////////////////////////////////////////
+// 日本語 (日本) resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_JPN)
+LANGUAGE LANG_JAPANESE, SUBLANG_DEFAULT
+
+#ifdef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE
+//
+
+1 TEXTINCLUDE 
+BEGIN
+    "resource.h\0"
+END
+
+2 TEXTINCLUDE 
+BEGIN
+    "#ifndef APSTUDIO_INVOKED\r\n"
+    "#include ""targetver.h""\r\n"
+    "#endif\r\n"
+    "#include ""afxres.h""\r\n"
+    "#include ""verrsrc.h""\r\n"
+    "\0"
+END
+
+3 TEXTINCLUDE 
+BEGIN
+    "#define _AFX_NO_SPLITTER_RESOURCES\r\n"
+    "#define _AFX_NO_OLE_RESOURCES\r\n"
+    "#define _AFX_NO_TRACKER_RESOURCES\r\n"
+    "#define _AFX_NO_PROPERTY_RESOURCES\r\n"
+    "\r\n"
+    "#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_JPN)\r\n"
+    "LANGUAGE 17, 1\r\n"
+    "#include ""res\\ThinBridgeChecker.rc2""  // Microsoft Visual C++ 以外で編集されたリソース\r\n"
+    "#include ""l.JPN\\afxres.rc""      // 標準コンポーネント\r\n"
+    "#endif\r\n"
+    "\0"
+END
+
+#endif    // APSTUDIO_INVOKED
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Icon
+//
+
+// Icon with lowest ID value placed first to ensure application icon
+// remains consistent on all systems.
+IDR_MAINFRAME           ICON                    "res\\ThinBridgeChecker.ico"
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Dialog
+//
+
+IDD_ThinBridgeChecker_DIALOG DIALOGEX 0, 0, 527, 306
+STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+EXSTYLE WS_EX_APPWINDOW
+CAPTION "ThinBridge環境チェッカー"
+FONT 9, "MS UI Gothic", 0, 0, 0x1
+BEGIN
+    EDITTEXT        IDC_EDIT1,7,7,513,229,ES_MULTILINE | WS_VSCROLL | WS_HSCROLL
+    GROUPBOX        "ツール",IDC_STATIC,7,239,285,60
+    PUSHBUTTON      "クリップボードにコピー",IDC_BUTTON1,15,255,79,14
+    PUSHBUTTON      "IE強制終了",IDC_BUTTON3,100,255,79,14
+    PUSHBUTTON      "ThinBridge設定画面を開く...",IDC_BUTTON7,184,255,102,14
+    PUSHBUTTON      "リダイレクト動作テスト(IE)...",IDC_BUTTON6,15,277,111,14
+    CONTROL         "設定ファイルの内容を収集する",IDC_CHECK1,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,303,242,131,10
+    DEFPUSHBUTTON   "情報収集",IDOK,303,256,149,43
+    PUSHBUTTON      "表示クリア",IDC_BUTTON2,461,255,59,16
+    PUSHBUTTON      "閉じる",IDCANCEL,461,278,59,21
+END
+
+IDD_DIALOG1 DIALOGEX 0, 0, 503, 60
+STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
+CAPTION "URL"
+FONT 9, "MS UI Gothic", 400, 0, 0x80
+BEGIN
+    LTEXT           "URL",IDC_STATIC,10,21,16,8
+    EDITTEXT        IDC_EDIT1,29,19,462,14,ES_AUTOHSCROLL
+    DEFPUSHBUTTON   "OK",IDOK,388,40,50,14
+    PUSHBUTTON      "キャンセル",IDCANCEL,442,40,50,14
+    LTEXT           "動作テストを行うURLを指定して下さい。",IDC_STATIC,10,5,119,8
+END
+
+IDD_DIALOG2 DIALOGEX 0, 0, 139, 72
+STYLE DS_SETFONT | WS_POPUP | WS_VISIBLE | WS_BORDER
+EXSTYLE WS_EX_TOPMOST
+FONT 10, "MS UI Gothic", 400, 0, 0x80
+BEGIN
+    LTEXT           "処理中です...\nしばらくお待ち下さい。",IDC_STATIC,7,8,125,19
+    LTEXT           "...",IDC_ST_STEP,7,53,125,13
+    LTEXT           "",IDC_ST,7,34,125,14,0,WS_EX_STATICEDGE
+END
+
+IDD_DLG_DEBUG_WND DIALOGEX 0, 0, 630, 380
+STYLE DS_SETFONT | WS_MINIMIZEBOX | WS_MAXIMIZEBOX | WS_POPUP | WS_CAPTION | WS_SYSMENU | WS_THICKFRAME
+CAPTION "TRACE Log Monitor  Window"
+FONT 10, "ＭＳ ゴシック", 400, 0, 0x80
+BEGIN
+    EDITTEXT        IDC_EDIT1,3,25,622,354,ES_MULTILINE | ES_AUTOVSCROLL | ES_AUTOHSCROLL | ES_WANTRETURN | WS_VSCROLL | WS_HSCROLL
+    PUSHBUTTON      "クリップボードにコピー",IDC_BUTTON1,5,5,93,14
+    PUSHBUTTON      "表示クリア",IDOK,103,5,50,14
+    PUSHBUTTON      "閉じる",IDCANCEL,155,5,50,14
+    LTEXT           "1行",IDC_STATIC_LINE,210,6,42,12,0,WS_EX_RIGHT | WS_EX_STATICEDGE
+END
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Version
+//
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION 9,8,7,6
+ PRODUCTVERSION 9,8,7,6
+ FILEFLAGSMASK 0x3fL
+#ifdef _DEBUG
+ FILEFLAGS 0x1L
+#else
+ FILEFLAGS 0x0L
+#endif
+ FILEOS 0x40004L
+ FILETYPE 0x1L
+ FILESUBTYPE 0x0L
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "041104b0"
+        BEGIN
+            VALUE "CompanyName", "ThinBridge"
+            VALUE "FileDescription", "ThinBridgeChecker"
+            VALUE "FileVersion", "9.8.7.6"
+            VALUE "InternalName", "ThinBridgeChecker.exe"
+            VALUE "LegalCopyright", "ThinBridge"
+            VALUE "OriginalFilename", "ThinBridgeChecker.exe"
+            VALUE "ProductName", "ThinBridgeChecker"
+            VALUE "ProductVersion", "9.8.7.6"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x411, 1200
+    END
+END
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// DESIGNINFO
+//
+
+#ifdef APSTUDIO_INVOKED
+GUIDELINES DESIGNINFO
+BEGIN
+    IDD_ThinBridgeChecker_DIALOG, DIALOG
+    BEGIN
+        LEFTMARGIN, 7
+        RIGHTMARGIN, 520
+        TOPMARGIN, 7
+        BOTTOMMARGIN, 299
+    END
+
+    IDD_DIALOG1, DIALOG
+    BEGIN
+        LEFTMARGIN, 7
+        RIGHTMARGIN, 496
+        TOPMARGIN, 7
+        BOTTOMMARGIN, 53
+    END
+
+    IDD_DIALOG2, DIALOG
+    BEGIN
+        LEFTMARGIN, 7
+        RIGHTMARGIN, 132
+    END
+
+    IDD_DLG_DEBUG_WND, DIALOG
+    BEGIN
+    END
+END
+#endif    // APSTUDIO_INVOKED
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// AFX_DIALOG_LAYOUT
+//
+
+IDD_ThinBridgeChecker_DIALOG AFX_DIALOG_LAYOUT
+BEGIN
+    0
+END
+
+#endif    // 日本語 (日本) resources
+/////////////////////////////////////////////////////////////////////////////
+
+
+
+#ifndef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 3 resource.
+//
+#define _AFX_NO_SPLITTER_RESOURCES
+#define _AFX_NO_OLE_RESOURCES
+#define _AFX_NO_TRACKER_RESOURCES
+#define _AFX_NO_PROPERTY_RESOURCES
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_JPN)
+LANGUAGE 17, 1
+#include "res\ThinBridgeChecker.rc2"  // Microsoft Visual C++ 以外で編集されたリソース
+#include "l.JPN\afxres.rc"      // 標準コンポーネント
+#endif
+
+/////////////////////////////////////////////////////////////////////////////
+#endif    // not APSTUDIO_INVOKED
+

--- a/script/fixtures/ThinBridgeRuleUpdater/ThinBridgeRuleUpdater.rc
+++ b/script/fixtures/ThinBridgeRuleUpdater/ThinBridgeRuleUpdater.rc
@@ -1,0 +1,258 @@
+// Microsoft Visual C++ generated resource script.
+//
+#include "resource.h"
+
+#define APSTUDIO_READONLY_SYMBOLS
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 2 resource.
+//
+#ifndef APSTUDIO_INVOKED
+#include "targetver.h"
+#endif
+#include "afxres.h"
+#include "verrsrc.h"
+
+/////////////////////////////////////////////////////////////////////////////
+#undef APSTUDIO_READONLY_SYMBOLS
+
+/////////////////////////////////////////////////////////////////////////////
+// 日本語 (日本) resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_JPN)
+LANGUAGE LANG_JAPANESE, SUBLANG_DEFAULT
+
+#ifdef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE
+//
+
+1 TEXTINCLUDE 
+BEGIN
+    "resource.h\0"
+END
+
+2 TEXTINCLUDE 
+BEGIN
+    "#ifndef APSTUDIO_INVOKED\r\n"
+    "#include ""targetver.h""\r\n"
+    "#endif\r\n"
+    "#include ""afxres.h""\r\n"
+    "#include ""verrsrc.h""\r\n"
+    "\0"
+END
+
+3 TEXTINCLUDE 
+BEGIN
+    "#define _AFX_NO_SPLITTER_RESOURCES\r\n"
+    "#define _AFX_NO_OLE_RESOURCES\r\n"
+    "#define _AFX_NO_TRACKER_RESOURCES\r\n"
+    "#define _AFX_NO_PROPERTY_RESOURCES\r\n"
+    "\r\n"
+    "#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_JPN)\r\n"
+    "LANGUAGE 17, 1\r\n"
+    "#include ""res\\ThinBridgeRuleUpdater.rc2""  // Microsoft Visual C++ 以外で編集されたリソース\r\n"
+    "#include ""l.JPN\\afxres.rc""      // 標準コンポーネント\r\n"
+    "#endif\r\n"
+    "\0"
+END
+
+#endif    // APSTUDIO_INVOKED
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Icon
+//
+
+// Icon with lowest ID value placed first to ensure application icon
+// remains consistent on all systems.
+IDR_MAINFRAME           ICON                    "res\\ThinBridgeRuleUpdater.ico"
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Dialog
+//
+
+IDD_ThinBridgeRuleUpdater_DIALOG DIALOGEX 0, 0, 475, 136
+STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+EXSTYLE WS_EX_APPWINDOW
+CAPTION "ThinBridge リダイレクト定義ファイル更新"
+FONT 9, "MS UI Gothic", 0, 0, 0x1
+BEGIN
+    ICON            IDR_MAINFRAME,IDC_STATIC,14,14,20,20
+    LTEXT           "ThinBridge リダイレクト定義ファイル取得先 (例 http://xxx/ThinBridge/ThinBridgeBHO.ini",IDC_STATIC,41,11,427,8
+    EDITTEXT        IDC_EDIT1,41,22,408,14,ES_AUTOHSCROLL
+    PUSHBUTTON      "+",IDC_BUTTON1,453,20,15,16
+    PUSHBUTTON      "接続＆取得データ テスト",IDC_BUTTON_TEST,376,38,92,22
+    LTEXT           "",IDC_STATIC_MSG,246,64,181,16
+    PUSHBUTTON      "ThinBridgeBHO.ini更新",IDC_BUTTON_WRITEINI_NOW,85,85,92,31
+    DEFPUSHBUTTON   "設定のみ保存",IDOK,181,85,92,31
+    PUSHBUTTON      "ThinBridgeBHO.ini更新＆設定保存",IDC_BUTTON_WRITEINI,277,85,136,31
+    PUSHBUTTON      "閉じる",IDCANCEL,417,85,50,31
+END
+
+IDD_DLG_MSGBOX DIALOGEX 0, 0, 556, 183
+STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
+CAPTION "詳細メッセージ"
+FONT 10, "ＭＳ ゴシック", 400, 0, 0x80
+BEGIN
+    EDITTEXT        IDC_EDIT1,6,6,542,152,ES_MULTILINE | ES_AUTOVSCROLL | ES_AUTOHSCROLL | ES_WANTRETURN | WS_VSCROLL | WS_HSCROLL
+    PUSHBUTTON      "OK",IDOK,445,162,50,14
+    PUSHBUTTON      "Cancel",IDCANCEL,499,162,50,14
+END
+
+IDD_DIALOG1 DIALOGEX 0, 0, 477, 235
+STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
+CAPTION "追加取得先"
+FONT 9, "MS UI Gothic", 400, 0, 0x80
+BEGIN
+    LTEXT           "ThinBridge リダイレクト定義ファイル取得先2",IDC_STATIC,7,11,466,8
+    EDITTEXT        IDC_EDIT2,7,21,466,13,ES_AUTOHSCROLL
+    LTEXT           "ThinBridge リダイレクト定義ファイル取得先3",IDC_STATIC,7,42,466,8
+    EDITTEXT        IDC_EDIT3,7,52,466,13,ES_AUTOHSCROLL
+    LTEXT           "ThinBridge リダイレクト定義ファイル取得先4",IDC_STATIC,7,73,466,8
+    EDITTEXT        IDC_EDIT4,7,84,466,13,ES_AUTOHSCROLL
+    LTEXT           "ThinBridge リダイレクト定義ファイル取得先5",IDC_STATIC,7,104,466,8
+    EDITTEXT        IDC_EDIT5,7,114,466,13,ES_AUTOHSCROLL
+    LTEXT           "ThinBridge リダイレクト定義ファイル取得先6",IDC_STATIC,7,135,466,8
+    EDITTEXT        IDC_EDIT6,7,146,466,13,ES_AUTOHSCROLL
+    GROUPBOX        "サーバー接続ルール",IDC_STATIC,7,167,189,28
+    CONTROL         "ランダム(負荷分散)",IDC_RADIO1,"Button",BS_AUTORADIOBUTTON,20,179,73,10
+    CONTROL         "設定順",IDC_RADIO2,"Button",BS_AUTORADIOBUTTON,120,179,39,10
+    LTEXT           "ピークアウト間隔",IDC_STATIC,237,179,49,8
+    EDITTEXT        IDC_EDIT_INT,293,176,24,16,ES_AUTOHSCROLL | ES_NUMBER
+    LTEXT           "分 (0-60)",IDC_STATIC,320,178,32,8
+    LTEXT           "取得先を複数（最大6個）設定した場合は、サーバー接続ルールにしたがって取得先を決定します。\nサーバーへの接続などで問題が発生した場合は順次設定されている他の取得先へと接続を試みます。",IDC_STATIC,7,200,353,28,0,WS_EX_CLIENTEDGE
+    DEFPUSHBUTTON   "OK",IDOK,366,214,50,14
+    PUSHBUTTON      "キャンセル",IDCANCEL,423,214,50,14
+END
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Version
+//
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION 9,8,7,6
+ PRODUCTVERSION 9,8,7,6
+ FILEFLAGSMASK 0x3fL
+#ifdef _DEBUG
+ FILEFLAGS 0x1L
+#else
+ FILEFLAGS 0x0L
+#endif
+ FILEOS 0x40004L
+ FILETYPE 0x1L
+ FILESUBTYPE 0x0L
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "041104b0"
+        BEGIN
+            VALUE "CompanyName", "ThinBridge"
+            VALUE "FileDescription", "ThinBridgeRuleUpdater"
+            VALUE "FileVersion", "9.8.7.6"
+            VALUE "InternalName", "ThinBridgeRuleUpdater.exe"
+            VALUE "LegalCopyright", "ThinBridge"
+            VALUE "OriginalFilename", "ThinBridgeRuleUpdater.exe"
+            VALUE "ProductName", "ThinBridgeRuleUpdater"
+            VALUE "ProductVersion", "9.8.7.6"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x411, 1200
+    END
+END
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// DESIGNINFO
+//
+
+#ifdef APSTUDIO_INVOKED
+GUIDELINES DESIGNINFO
+BEGIN
+    IDD_ThinBridgeRuleUpdater_DIALOG, DIALOG
+    BEGIN
+        LEFTMARGIN, 7
+        RIGHTMARGIN, 468
+        TOPMARGIN, 7
+        BOTTOMMARGIN, 129
+    END
+
+    IDD_DLG_MSGBOX, DIALOG
+    BEGIN
+    END
+
+    IDD_DIALOG1, DIALOG
+    BEGIN
+        LEFTMARGIN, 7
+        RIGHTMARGIN, 473
+        TOPMARGIN, 7
+        BOTTOMMARGIN, 228
+    END
+END
+#endif    // APSTUDIO_INVOKED
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// AFX_DIALOG_LAYOUT
+//
+
+IDD_ThinBridgeRuleUpdater_DIALOG AFX_DIALOG_LAYOUT
+BEGIN
+    0
+END
+
+IDD_DLG_MSGBOX AFX_DIALOG_LAYOUT
+BEGIN
+    0
+END
+
+IDD_DIALOG1 AFX_DIALOG_LAYOUT
+BEGIN
+    0
+END
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// String Table
+//
+
+STRINGTABLE
+BEGIN
+    IDS_ABOUTBOX            "バージョン情報 ThinBridgeRuleUpdater(&A)..."
+END
+
+#endif    // 日本語 (日本) resources
+/////////////////////////////////////////////////////////////////////////////
+
+
+
+#ifndef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 3 resource.
+//
+#define _AFX_NO_SPLITTER_RESOURCES
+#define _AFX_NO_OLE_RESOURCES
+#define _AFX_NO_TRACKER_RESOURCES
+#define _AFX_NO_PROPERTY_RESOURCES
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_JPN)
+LANGUAGE 17, 1
+#include "res\ThinBridgeRuleUpdater.rc2"  // Microsoft Visual C++ 以外で編集されたリソース
+#include "l.JPN\afxres.rc"      // 標準コンポーネント
+#endif
+
+/////////////////////////////////////////////////////////////////////////////
+#endif    // not APSTUDIO_INVOKED
+

--- a/script/fixtures/ThinBridgeX64.iss
+++ b/script/fixtures/ThinBridgeX64.iss
@@ -1,0 +1,265 @@
+﻿;ThinBridge Setup--
+
+[Setup]
+AppName=ThinBridge
+AppVerName=ThinBridge
+VersionInfoVersion=9.8.7.6
+AppVersion=9.8.7.6
+AppMutex=ThinBridgeSetup
+;DefaultDirName=C:\ThinBridge
+DefaultDirName={code:GetProgramFiles}\ThinBridge
+Compression=lzma2
+SolidCompression=yes
+OutputDir=SetupOutput
+OutputBaseFilename=ThinBridgeSetup_x64
+AppPublisher=ThinBridge
+WizardImageStretch=no
+VersionInfoDescription=ThinBridgeSetup
+ArchitecturesAllowed=x64
+ArchitecturesInstallIn64BitMode=x64
+DefaultGroupName=ThinBridge
+UninstallDisplayIcon={app}\ThinBridge.exe
+
+[Registry]
+Root: HKLM; Subkey: "Software\ThinBridge"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "Software\ThinBridge"; ValueType: string; ValueName: "Path"; ValueData: "{app}\"
+Root: HKLM; Subkey: "Software\ThinBridge"; ValueType: string; ValueName: "ClientType"; ValueData: ""
+Root: HKLM; Subkey: "Software\ThinBridge"; ValueType: string; ValueName: "Version"; ValueData: "9.8.7.6"
+Root: HKLM; Subkey: "Software\ThinBridge"; ValueType: string; ValueName: "Rulefile"; ValueData: "{app}\ThinBridgeBHO.ini"
+Root: HKLM; Subkey: "Software\ThinBridge"; ValueType: string; ValueName: "RCAPfile"; ValueData: "{app}\ResourceCap.ini"
+Root: HKLM; Subkey: "Software\ThinBridge"; ValueType: string; ValueName: "ExtensionExecfile"; ValueData: "{app}\TBRedirector.exe"
+
+Root: HKLM; Subkey: "Software\WOW6432Node\ThinBridge"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "Software\WOW6432Node\ThinBridge"; ValueType: string; ValueName: "Path"; ValueData: "{app}\"
+Root: HKLM; Subkey: "Software\WOW6432Node\ThinBridge"; ValueType: string; ValueName: "ClientType"; ValueData: ""
+Root: HKLM; Subkey: "Software\WOW6432Node\ThinBridge"; ValueType: string; ValueName: "Version"; ValueData: "9.8.7.6"
+Root: HKLM; Subkey: "Software\WOW6432Node\ThinBridge"; ValueType: string; ValueName: "Rulefile"; ValueData: "{app}\ThinBridgeBHO.ini"
+Root: HKLM; Subkey: "Software\WOW6432Node\ThinBridge"; ValueType: string; ValueName: "RCAPfile"; ValueData: "{app}\ResourceCap.ini"
+Root: HKLM; Subkey: "Software\WOW6432Node\ThinBridge"; ValueType: string; ValueName: "ExtensionExecfile"; ValueData: "{app}\TBRedirector.exe"
+
+
+;IE Addin
+;アドオンの有効化
+;Root: HKLM; Subkey: "Software\Microsoft\Windows\CurrentVersion\Policies\Ext"; ValueType: dword; ValueName: "ListBox_Support_CLSID"; ValueData: "1"
+;Root: HKLM; Subkey: "Software\Microsoft\Windows\CurrentVersion\Policies\Ext\CLSID"; ValueType: string; ValueName: "{{3A56619B-37AC-40DA-833E-410F3BEDCBDC}"; ValueData: "1";Flags: uninsdeletevalue
+
+;Edge
+;Root: HKLM; Subkey: "SOFTWARE\Policies\Microsoft\Edge\ExtensionInstallForcelist"; ValueType: string; ValueName:{code:GetEdgeExtensionIndex}; ValueData:"famoofbkcpjdkihdngnhgbdfkfenhcnf";Flags:uninsdeletevalue
+Root: HKLM; Subkey: "SOFTWARE\Microsoft\Edge\NativeMessagingHosts\com.clear_code.thinbridge"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\Microsoft\Edge\NativeMessagingHosts\com.clear_code.thinbridge"; ValueType: string; ValueData: "{app}\ThinBridgeHost\edge.json";
+
+;Firefox
+Root: HKLM; Subkey: "SOFTWARE\Mozilla\NativeMessagingHosts\com.clear_code.thinbridge"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\Mozilla\NativeMessagingHosts\com.clear_code.thinbridge"; ValueType: string; ValueData: "{app}\ThinBridgeHost\firefox.json";
+
+;Chrome
+Root: HKLM; Subkey: "SOFTWARE\Google\Chrome\NativeMessagingHosts\com.clear_code.thinbridge"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\Google\Chrome\NativeMessagingHosts\com.clear_code.thinbridge"; ValueType: string; ValueData: "{app}\ThinBridgeHost\chrome.json";
+
+;Default Browser
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge"; ValueType: string; ValueData: "ThinBridge";
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge\Capabilities"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge\Capabilities"; ValueType: string; ValueName: "ApplicationDescription"; ValueData: "ThinBridge Browser Redirector"
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge\Capabilities"; ValueType: string; ValueName: "ApplicationIcon"; ValueData: "{app}\ThinBridge.exe"
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge\Capabilities"; ValueType: string; ValueName: "ApplicationName"; ValueData: "ThinBridge"
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge\Capabilities\Startmenu"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge\Capabilities\Startmenu"; ValueType: string; ValueName: "StartMenuInternet"; ValueData: "ThinBridge"
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge\Capabilities\URLAssociations"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge\Capabilities\URLAssociations"; ValueType: string; ValueName: "http"; ValueData: "ThinBridgeURL"
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge\Capabilities\URLAssociations"; ValueType: string; ValueName: "https"; ValueData: "ThinBridgeURL"
+
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge\DefaultIcon"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge\DefaultIcon"; ValueType: string; ValueData: "{app}\ThinBridge.exe"
+
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge\InstallInfo"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge\InstallInfo"; ValueType: string; ValueName: "HideIconsCommand"; ValueData: """{app}\ThinBridge.exe"" --hide-icons"
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge\InstallInfo"; ValueType: string; ValueName: "ReinstallCommand"; ValueData: """{app}\ThinBridge.exe"" --make-default-browser"
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge\InstallInfo"; ValueType: string; ValueName: "ShowIconsCommand"; ValueData: """{app}\ThinBridge.exe"" --show-icons"
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge\InstallInfo"; ValueType: dword; ValueName: "IconsVisible"; ValueData: "1"
+
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge\shell"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge\shell\open"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge\shell\open\command"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge\shell\open\command"; ValueType: string; ValueData: """{app}\TBRedirector.exe"" ""%1"""
+
+Root: HKLM; Subkey: "SOFTWARE\RegisteredApplications"; ValueType: string; ValueName: "ThinBridge"; ValueData: "Software\Clients\StartMenuInternet\ThinBridge\Capabilities"
+
+
+
+Root: HKLM; Subkey: "SOFTWARE\Classes\ThinBridgeURL"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\Classes\ThinBridgeURL"; ValueType: string; ValueData: "ThinBridge"
+Root: HKLM; Subkey: "SOFTWARE\Classes\ThinBridgeURL"; ValueType: string; ValueName: "AppUserModelId"; ValueData: "ThinBridge"
+
+Root: HKLM; Subkey: "SOFTWARE\Classes\ThinBridgeURL\Application"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\Classes\ThinBridgeURL\Application"; ValueType: string; ValueName: "ApplicationCompany"; ValueData: "ThinBridge"
+Root: HKLM; Subkey: "SOFTWARE\Classes\ThinBridgeURL\Application"; ValueType: string; ValueName: "ApplicationDescription"; ValueData: "ThinBridge Browser Redirector"
+Root: HKLM; Subkey: "SOFTWARE\Classes\ThinBridgeURL\Application"; ValueType: string; ValueName: "ApplicationIcon"; ValueData: "{app}\ThinBridge.exe"
+Root: HKLM; Subkey: "SOFTWARE\Classes\ThinBridgeURL\Application"; ValueType: string; ValueName: "ApplicationName"; ValueData: "ThinBridge"
+Root: HKLM; Subkey: "SOFTWARE\Classes\ThinBridgeURL\Application"; ValueType: string; ValueName: "AppUserModelId"; ValueData: "ThinBridge"
+
+Root: HKLM; Subkey: "SOFTWARE\Classes\ThinBridgeURL\DefaultIcon"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\Classes\ThinBridgeURL\DefaultIcon"; ValueType: string; ValueData: "{app}\ThinBridge.exe,0"
+Root: HKLM; Subkey: "SOFTWARE\Classes\ThinBridgeURL\shell"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\Classes\ThinBridgeURL\shell\open"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\Classes\ThinBridgeURL\shell\open\command"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\Classes\ThinBridgeURL\shell\open\command"; ValueType: string; ValueData: """{app}\TBRedirector.exe"" ""%1"""
+
+
+;///////////////////
+Root: HKLM; Subkey: "SOFTWARE\WOW6432Node\Clients\StartMenuInternet\ThinBridge"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\WOW6432Node\Clients\StartMenuInternet\ThinBridge"; ValueType: string; ValueData: "ThinBridge";
+Root: HKLM; Subkey: "SOFTWARE\WOW6432Node\Clients\StartMenuInternet\ThinBridge\Capabilities"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\WOW6432Node\Clients\StartMenuInternet\ThinBridge\Capabilities"; ValueType: string; ValueName: "ApplicationDescription"; ValueData: "ThinBridge Browser Redirector"
+Root: HKLM; Subkey: "SOFTWARE\WOW6432Node\Clients\StartMenuInternet\ThinBridge\Capabilities"; ValueType: string; ValueName: "ApplicationIcon"; ValueData: "{app}\ThinBridge.exe,0"
+Root: HKLM; Subkey: "SOFTWARE\WOW6432Node\Clients\StartMenuInternet\ThinBridge\Capabilities"; ValueType: string; ValueName: "ApplicationName"; ValueData: "ThinBridge"
+Root: HKLM; Subkey: "SOFTWARE\WOW6432Node\Clients\StartMenuInternet\ThinBridge\Capabilities\Startmenu"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\WOW6432Node\Clients\StartMenuInternet\ThinBridge\Capabilities\Startmenu"; ValueType: string; ValueName: "StartMenuInternet"; ValueData: "ThinBridge"
+Root: HKLM; Subkey: "SOFTWARE\WOW6432Node\Clients\StartMenuInternet\ThinBridge\Capabilities\URLAssociations"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\WOW6432Node\Clients\StartMenuInternet\ThinBridge\Capabilities\URLAssociations"; ValueType: string; ValueName: "http"; ValueData: "ThinBridgeURL"
+Root: HKLM; Subkey: "SOFTWARE\WOW6432Node\Clients\StartMenuInternet\ThinBridge\Capabilities\URLAssociations"; ValueType: string; ValueName: "https"; ValueData: "ThinBridgeURL"
+
+Root: HKLM; Subkey: "SOFTWARE\WOW6432Node\Clients\StartMenuInternet\ThinBridge\DefaultIcon"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\WOW6432Node\Clients\StartMenuInternet\ThinBridge\DefaultIcon"; ValueType: string; ValueData: "{app}\ThinBridge.exe"
+
+Root: HKLM; Subkey: "SOFTWARE\WOW6432Node\Clients\StartMenuInternet\ThinBridge\shell"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\WOW6432Node\Clients\StartMenuInternet\ThinBridge\shell\open"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\WOW6432Node\Clients\StartMenuInternet\ThinBridge\shell\open\command"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\WOW6432Node\Clients\StartMenuInternet\ThinBridge\shell\open\command"; ValueType: string; ValueData: """{app}\TBRedirector.exe"" ""%1"""
+
+Root: HKLM; Subkey: "SOFTWARE\WOW6432Node\Clients\StartMenuInternet\ThinBridge\InstallInfo"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\WOW6432Node\Clients\StartMenuInternet\ThinBridge\InstallInfo"; ValueType: string; ValueName: "HideIconsCommand"; ValueData: """{app}\ThinBridge.exe"" --hide-icons"
+Root: HKLM; Subkey: "SOFTWARE\WOW6432Node\Clients\StartMenuInternet\ThinBridge\InstallInfo"; ValueType: string; ValueName: "ReinstallCommand"; ValueData: """{app}\ThinBridge.exe"" --make-default-browser"
+Root: HKLM; Subkey: "SOFTWARE\WOW6432Node\Clients\StartMenuInternet\ThinBridge\InstallInfo"; ValueType: string; ValueName: "ShowIconsCommand"; ValueData: """{app}\ThinBridge.exe"" --show-icons"
+Root: HKLM; Subkey: "SOFTWARE\WOW6432Node\Clients\StartMenuInternet\ThinBridge\InstallInfo"; ValueType: dword; ValueName: "IconsVisible"; ValueData: "1"
+
+Root: HKLM; Subkey: "SOFTWARE\WOW6432Node\Clients\StartMenuInternet\ThinBridge\shell"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\WOW6432Node\Clients\StartMenuInternet\ThinBridge\shell\open"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\WOW6432Node\Clients\StartMenuInternet\ThinBridge\shell\open\command"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\WOW6432Node\Clients\StartMenuInternet\ThinBridge\shell\open\command"; ValueType: string; ValueData: """{app}\TBRedirector.exe"" ""%1"""
+
+Root: HKLM; Subkey: "SOFTWARE\WOW6432Node\RegisteredApplications"; ValueType: string; ValueName: "ThinBridge"; ValueData: "Software\Clients\StartMenuInternet\ThinBridge\Capabilities"
+
+
+[Languages]
+Name: jp; MessagesFile: "compiler:Languages\Japanese.isl"
+
+
+[Files]
+;exe
+Source: "Release\TBRedirector.exe"; DestDir: "{app}\";Flags: ignoreversion;permissions:users-readexec admins-full system-full
+Source: "Release\ThinBridge.exe"; DestDir: "{app}\";Flags: ignoreversion;permissions:users-readexec admins-full system-full
+Source: "Release\ThinBridgeChecker.exe"; DestDir: "{app}\";Flags: ignoreversion;permissions:users-readexec admins-full system-full
+Source: "Release\ThinBridgeRuleUpdater.exe"; DestDir: "{app}\";Flags: ignoreversion;permissions:users-readexec admins-full system-full
+Source: "Release\ThinBridgeRuleUpdaterSetting.exe"; DestDir: "{app}\";Flags: ignoreversion;permissions:users-readexec admins-full system-full
+Source: "Release\ThinBridgeSetting.exe"; DestDir: "{app}\";Flags: ignoreversion;permissions:users-readexec admins-full system-full
+Source: "Release\TBo365URLSyncSetting.exe"; DestDir: "{app}\";Flags: ignoreversion;permissions:users-readexec admins-full system-full
+
+;dll
+Source: "Release\ThinBridgeBHO.dll"; DestDir: "{app}\";Flags: ignoreversion regserver 32bit;permissions:users-readexec admins-full system-full
+Source: "Release\ThinBridgeBHO64.dll"; DestDir: "{app}\";Flags: ignoreversion regserver 64bit; Check: IsWin64;permissions:users-readexec admins-full system-full
+
+;host
+Source: "Release\ThinBridgeTalk.exe"; DestDir: "{app}\ThinBridgeHost";Flags: ignoreversion;permissions:users-readexec admins-full system-full
+
+;edge
+Source: "Resources\edge.json"; DestDir: "{app}\ThinBridgeHost";Flags: ignoreversion;permissions:users-readexec admins-full system-full
+;firefox
+Source: "Resources\firefox.json"; DestDir: "{app}\ThinBridgeHost";Flags: ignoreversion;permissions:users-readexec admins-full system-full
+;Chrome
+Source: "Resources\chrome.json"; DestDir: "{app}\ThinBridgeHost";Flags: ignoreversion;permissions:users-readexec admins-full system-full
+
+[Icons]
+Name: "{group}\リダイレクト定義設定"; Filename: "{app}\ThinBridgeSetting.exe"; WorkingDir: "{app}"
+Name: "{group}\環境チェッカー"; Filename: "{app}\ThinBridgeChecker.exe"; WorkingDir: "{app}"
+Name: "{group}\リダイレクト定義自動更新設定"; Filename: "{app}\ThinBridgeRuleUpdaterSetting.exe"; WorkingDir: "{app}"
+Name: "{commonstartup}\ThinBridgeRuleUpdater"; Filename: "{app}\ThinBridgeRuleUpdater.exe"; WorkingDir: "{app}"
+
+[Dirs]
+Name: "{app}";Permissions: users-modify
+;log関連はアンインストールで消さない
+Name: "{app}\TBUpdateLog";Permissions: users-modify;Flags: uninsneveruninstall
+
+[Run] 
+Filename: "{app}\ThinBridgeChecker.exe";Parameters: "/log"; Flags: runhidden 
+
+Filename: "{sys}\icacls.exe";Parameters: """{app}\TBo365URLSyncSetting.exe"" /inheritance:r"; Flags: runhidden shellexec
+Filename: "{sys}\icacls.exe";Parameters: """{app}\TBRedirector.exe"" /inheritance:r"; Flags: runhidden shellexec
+Filename: "{sys}\icacls.exe";Parameters: """{app}\ThinBridge.exe"" /inheritance:r"; Flags: runhidden shellexec
+Filename: "{sys}\icacls.exe";Parameters: """{app}\ThinBridgeSetting.exe"" /inheritance:r"; Flags: runhidden shellexec
+Filename: "{sys}\icacls.exe";Parameters: """{app}\ThinBridgeChecker.exe"" /inheritance:r"; Flags: runhidden shellexec
+Filename: "{sys}\icacls.exe";Parameters: """{app}\ThinBridgeRuleUpdater.exe"" /inheritance:r"; Flags: runhidden shellexec
+Filename: "{sys}\icacls.exe";Parameters: """{app}\ThinBridgeRuleUpdaterSetting.exe"" /inheritance:r"; Flags: runhidden shellexec
+Filename: "{sys}\icacls.exe";Parameters: """{app}\ThinBridgeBHO.dll"" /inheritance:r"; Flags: runhidden shellexec
+Filename: "{sys}\icacls.exe";Parameters: """{app}\ThinBridgeBHO64.dll"" /inheritance:r"; Flags: runhidden shellexec
+Filename: "{sys}\icacls.exe";Parameters: """{app}\ThinBridgeHost\ThinBridgeTalk.exe"" /inheritance:r"; Flags: runhidden shellexec
+Filename: "{sys}\icacls.exe";Parameters: """{app}\ThinBridgeHost\edge.json"" /inheritance:r"; Flags: runhidden shellexec
+Filename: "{sys}\icacls.exe";Parameters: """{app}\ThinBridgeHost\firefox.json"" /inheritance:r"; Flags: runhidden shellexec
+Filename: "{sys}\icacls.exe";Parameters: """{app}\ThinBridgeHost\chrome.json"" /inheritance:r"; Flags: runhidden shellexec
+
+[UninstallRun]
+
+[Code]
+function GetProgramFiles(Param: string): string;
+  begin
+    if IsWin64 then Result := ExpandConstant('{pf64}')
+    else Result := ExpandConstant('{pf32}')
+  end;
+
+procedure TaskKill(FileName: String);
+var
+  ResultCode: Integer;
+begin
+    Exec(ExpandConstant('taskkill.exe'), '/f /im ' + '"' + FileName + '"', '', SW_HIDE,ewWaitUntilTerminated, ResultCode);
+end;
+function InitializeSetup():Boolean;
+begin 
+	TaskKill('iexplore.exe');
+	TaskKill('msedge.exe');
+	TaskKill('TBRedirector.exe');
+	TaskKill('ThinBridge.exe');
+	TaskKill('ThinBridgeSetting.exe');
+	TaskKill('ThinBridgeChecker.exe');
+	TaskKill('ThinBridgeRuleUpdater.exe');
+	TaskKill('ThinBridgeRuleUpdaterSetting.exe');
+	Result := True; 
+end; 
+
+function GetEdgeExtensionIndex(Value: string):string;
+var
+  Names: TArrayOfString;
+  I: Integer;
+  sIndex: String;
+	sValue:String;
+	iMax:Integer;
+	iTemp:Integer;
+begin
+	iMax :=168;
+  if RegGetValueNames(HKLM, 'SOFTWARE\Policies\Microsoft\Edge\ExtensionInstallForcelist', Names) then
+  begin
+    sIndex := '';
+		iMax :=iMax-1;
+		iTemp :=0;
+    for I := 0 to GetArrayLength(Names)-1 do
+		begin
+      sIndex := Names[I];
+			if(sIndex<>'') then
+			begin
+				RegQueryStringValue(HKLM,'SOFTWARE\Policies\Microsoft\Edge\ExtensionInstallForcelist',sIndex,sValue);
+        if(sValue='famoofbkcpjdkihdngnhgbdfkfenhcnf')then
+				begin
+				  Result:=sIndex;
+				  exit;
+				end	else
+				begin
+					iTemp := StrToInt(sIndex);
+					if(iTemp > iMax) then
+						iMax := iTemp;
+				end;
+			end;
+		end;
+		iMax := iMax +1;
+    //MsgBox('List of subkeys:'#13#10#13#10 + IntToStr(iMax), mbInformation, MB_OK);
+  end;
+	Result:=IntToStr(iMax);
+end;	

--- a/script/fixtures/ThinBridgeX86.iss
+++ b/script/fixtures/ThinBridgeX86.iss
@@ -1,0 +1,228 @@
+﻿;ThinBridge Setup--
+
+[Setup]
+AppName=ThinBridge
+AppVerName=ThinBridge
+VersionInfoVersion=9.8.7.6
+AppVersion=9.8.7.6
+AppMutex=ThinBridgeSetup
+;DefaultDirName=C:\ThinBridge
+DefaultDirName={code:GetProgramFiles}\ThinBridge
+Compression=lzma2
+SolidCompression=yes
+OutputDir=SetupOutput
+OutputBaseFilename=ThinBridgeSetup_x86
+AppPublisher=ThinBridge
+WizardImageStretch=no
+VersionInfoDescription=ThinBridgeSetup
+ArchitecturesAllowed=x86
+;ArchitecturesInstallIn64BitMode=x64
+DefaultGroupName=ThinBridge
+UninstallDisplayIcon={app}\ThinBridge.exe
+
+[Registry]
+Root: HKLM; Subkey: "Software\ThinBridge"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "Software\ThinBridge"; ValueType: string; ValueName: "Path"; ValueData: "{app}\"
+Root: HKLM; Subkey: "Software\ThinBridge"; ValueType: string; ValueName: "ClientType"; ValueData: ""
+Root: HKLM; Subkey: "Software\ThinBridge"; ValueType: string; ValueName: "Version"; ValueData: "9.8.7.6"
+Root: HKLM; Subkey: "Software\ThinBridge"; ValueType: string; ValueName: "Rulefile"; ValueData: "{app}\ThinBridgeBHO.ini"
+Root: HKLM; Subkey: "Software\ThinBridge"; ValueType: string; ValueName: "RCAPfile"; ValueData: "{app}\ResourceCap.ini"
+Root: HKLM; Subkey: "Software\ThinBridge"; ValueType: string; ValueName: "ExtensionExecfile"; ValueData: "{app}\TBRedirector.exe"
+
+;Root: HKLM; Subkey: "Software\WOW6432Node\ThinBridge"; Flags: uninsdeletekey
+;Root: HKLM; Subkey: "Software\WOW6432Node\ThinBridge"; ValueType: string; ValueName: "Path"; ValueData: "{app}\"
+;Root: HKLM; Subkey: "Software\WOW6432Node\ThinBridge"; ValueType: string; ValueName: "ClientType"; ValueData: ""
+;Root: HKLM; Subkey: "Software\WOW6432Node\ThinBridge"; ValueType: string; ValueName: "Version"; ValueData: "9.8.7.6"
+;Root: HKLM; Subkey: "Software\WOW6432Node\ThinBridge"; ValueType: string; ValueName: "Rulefile"; ValueData: "{app}\ThinBridgeBHO.ini"
+;Root: HKLM; Subkey: "Software\WOW6432Node\ThinBridge"; ValueType: string; ValueName: "ExtensionExecfile"; ValueData: "{app}\TBRedirector.exe"
+
+
+;IE Addin
+;アドオンの有効化
+;Root: HKLM; Subkey: "Software\Microsoft\Windows\CurrentVersion\Policies\Ext"; ValueType: dword; ValueName: "ListBox_Support_CLSID"; ValueData: "1"
+;Root: HKLM; Subkey: "Software\Microsoft\Windows\CurrentVersion\Policies\Ext\CLSID"; ValueType: string; ValueName: "{{3A56619B-37AC-40DA-833E-410F3BEDCBDC}"; ValueData: "1";Flags: uninsdeletevalue
+
+;Edge
+;Root: HKLM; Subkey: "SOFTWARE\Policies\Microsoft\Edge\ExtensionInstallForcelist"; ValueType: string; ValueName:{code:GetEdgeExtensionIndex}; ValueData:"famoofbkcpjdkihdngnhgbdfkfenhcnf";Flags:uninsdeletevalue
+Root: HKLM; Subkey: "SOFTWARE\Microsoft\Edge\NativeMessagingHosts\com.clear_code.thinbridge"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\Microsoft\Edge\NativeMessagingHosts\com.clear_code.thinbridge"; ValueType: string; ValueData: "{app}\ThinBridgeHost\edge.json";
+
+;Firefox
+Root: HKLM; Subkey: "SOFTWARE\Mozilla\NativeMessagingHosts\com.clear_code.thinbridge"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\Mozilla\NativeMessagingHosts\com.clear_code.thinbridge"; ValueType: string; ValueData: "{app}\ThinBridgeHost\firefox.json";
+
+;Chrome
+Root: HKLM; Subkey: "SOFTWARE\Google\Chrome\NativeMessagingHosts\com.clear_code.thinbridge"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\Google\Chrome\NativeMessagingHosts\com.clear_code.thinbridge"; ValueType: string; ValueData: "{app}\ThinBridgeHost\chrome.json";
+
+;Default Browser
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge"; ValueType: string; ValueData: "ThinBridge";
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge\Capabilities"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge\Capabilities"; ValueType: string; ValueName: "ApplicationDescription"; ValueData: "ThinBridge Browser Redirector"
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge\Capabilities"; ValueType: string; ValueName: "ApplicationIcon"; ValueData: "{app}\ThinBridge.exe"
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge\Capabilities"; ValueType: string; ValueName: "ApplicationName"; ValueData: "ThinBridge"
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge\Capabilities\Startmenu"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge\Capabilities\Startmenu"; ValueType: string; ValueName: "StartMenuInternet"; ValueData: "ThinBridge"
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge\Capabilities\URLAssociations"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge\Capabilities\URLAssociations"; ValueType: string; ValueName: "http"; ValueData: "ThinBridgeURL"
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge\Capabilities\URLAssociations"; ValueType: string; ValueName: "https"; ValueData: "ThinBridgeURL"
+
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge\DefaultIcon"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge\DefaultIcon"; ValueType: string; ValueData: "{app}\ThinBridge.exe"
+
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge\InstallInfo"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge\InstallInfo"; ValueType: string; ValueName: "HideIconsCommand"; ValueData: """{app}\ThinBridge.exe"" --hide-icons"
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge\InstallInfo"; ValueType: string; ValueName: "ReinstallCommand"; ValueData: """{app}\ThinBridge.exe"" --make-default-browser"
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge\InstallInfo"; ValueType: string; ValueName: "ShowIconsCommand"; ValueData: """{app}\ThinBridge.exe"" --show-icons"
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge\InstallInfo"; ValueType: dword; ValueName: "IconsVisible"; ValueData: "1"
+
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge\shell"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge\shell\open"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge\shell\open\command"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\Clients\StartMenuInternet\ThinBridge\shell\open\command"; ValueType: string; ValueData: """{app}\TBRedirector.exe"" ""%1"""
+
+Root: HKLM; Subkey: "SOFTWARE\RegisteredApplications"; ValueType: string; ValueName: "ThinBridge"; ValueData: "Software\Clients\StartMenuInternet\ThinBridge\Capabilities"
+
+
+
+Root: HKLM; Subkey: "SOFTWARE\Classes\ThinBridgeURL"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\Classes\ThinBridgeURL"; ValueType: string; ValueData: "ThinBridge"
+Root: HKLM; Subkey: "SOFTWARE\Classes\ThinBridgeURL"; ValueType: string; ValueName: "AppUserModelId"; ValueData: "ThinBridge"
+
+Root: HKLM; Subkey: "SOFTWARE\Classes\ThinBridgeURL\Application"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\Classes\ThinBridgeURL\Application"; ValueType: string; ValueName: "ApplicationCompany"; ValueData: "ThinBridge"
+Root: HKLM; Subkey: "SOFTWARE\Classes\ThinBridgeURL\Application"; ValueType: string; ValueName: "ApplicationDescription"; ValueData: "ThinBridge Browser Redirector"
+Root: HKLM; Subkey: "SOFTWARE\Classes\ThinBridgeURL\Application"; ValueType: string; ValueName: "ApplicationIcon"; ValueData: "{app}\ThinBridge.exe"
+Root: HKLM; Subkey: "SOFTWARE\Classes\ThinBridgeURL\Application"; ValueType: string; ValueName: "ApplicationName"; ValueData: "ThinBridge"
+Root: HKLM; Subkey: "SOFTWARE\Classes\ThinBridgeURL\Application"; ValueType: string; ValueName: "AppUserModelId"; ValueData: "ThinBridge"
+
+Root: HKLM; Subkey: "SOFTWARE\Classes\ThinBridgeURL\DefaultIcon"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\Classes\ThinBridgeURL\DefaultIcon"; ValueType: string; ValueData: "{app}\ThinBridge.exe,0"
+Root: HKLM; Subkey: "SOFTWARE\Classes\ThinBridgeURL\shell"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\Classes\ThinBridgeURL\shell\open"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\Classes\ThinBridgeURL\shell\open\command"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "SOFTWARE\Classes\ThinBridgeURL\shell\open\command"; ValueType: string; ValueData: """{app}\TBRedirector.exe"" ""%1"""
+
+[Languages]
+Name: jp; MessagesFile: "compiler:Languages\Japanese.isl"
+
+
+[Files]
+;exe
+Source: "Release\TBRedirector.exe"; DestDir: "{app}\";Flags: ignoreversion;permissions:users-readexec admins-full system-full
+Source: "Release\ThinBridge.exe"; DestDir: "{app}\";Flags: ignoreversion;permissions:users-readexec admins-full system-full
+Source: "Release\ThinBridgeChecker.exe"; DestDir: "{app}\";Flags: ignoreversion;permissions:users-readexec admins-full system-full
+Source: "Release\ThinBridgeRuleUpdater.exe"; DestDir: "{app}\";Flags: ignoreversion;permissions:users-readexec admins-full system-full
+Source: "Release\ThinBridgeRuleUpdaterSetting.exe"; DestDir: "{app}\";Flags: ignoreversion;permissions:users-readexec admins-full system-full
+Source: "Release\ThinBridgeSetting.exe"; DestDir: "{app}\";Flags: ignoreversion;permissions:users-readexec admins-full system-full
+Source: "Release\TBo365URLSyncSetting.exe"; DestDir: "{app}\";Flags: ignoreversion;permissions:users-readexec admins-full system-full
+
+;dll
+Source: "Release\ThinBridgeBHO.dll"; DestDir: "{app}\";Flags: ignoreversion regserver 32bit;permissions:users-readexec admins-full system-full
+Source: "Release\ThinBridgeBHO64.dll"; DestDir: "{app}\";Flags: ignoreversion regserver 64bit; Check: IsWin64;permissions:users-readexec admins-full system-full
+
+;host
+Source: "Release\ThinBridgeTalk.exe"; DestDir: "{app}\ThinBridgeHost";Flags: ignoreversion;permissions:users-readexec admins-full system-full
+
+;edge
+Source: "Resources\edge.json"; DestDir: "{app}\ThinBridgeHost";Flags: ignoreversion;permissions:users-readexec admins-full system-full
+;firefox
+Source: "Resources\firefox.json"; DestDir: "{app}\ThinBridgeHost";Flags: ignoreversion;permissions:users-readexec admins-full system-full
+;Chrome
+Source: "Resources\chrome.json"; DestDir: "{app}\ThinBridgeHost";Flags: ignoreversion;permissions:users-readexec admins-full system-full
+
+[Icons]
+Name: "{group}\リダイレクト定義設定"; Filename: "{app}\ThinBridgeSetting.exe"; WorkingDir: "{app}"
+Name: "{group}\環境チェッカー"; Filename: "{app}\ThinBridgeChecker.exe"; WorkingDir: "{app}"
+Name: "{group}\リダイレクト定義自動更新設定"; Filename: "{app}\ThinBridgeRuleUpdaterSetting.exe"; WorkingDir: "{app}"
+Name: "{commonstartup}\ThinBridgeRuleUpdater"; Filename: "{app}\ThinBridgeRuleUpdater.exe"; WorkingDir: "{app}"
+
+[Dirs]
+Name: "{app}";Permissions: users-modify
+;log関連はアンインストールで消さない
+Name: "{app}\TBUpdateLog";Permissions: users-modify;Flags: uninsneveruninstall
+
+[Run] 
+Filename: "{app}\ThinBridgeChecker.exe";Parameters: "/log"; Flags: runhidden 
+
+Filename: "{sys}\icacls.exe";Parameters: """{app}\TBo365URLSyncSetting.exe"" /inheritance:r"; Flags: runhidden shellexec
+Filename: "{sys}\icacls.exe";Parameters: """{app}\TBRedirector.exe"" /inheritance:r"; Flags: runhidden shellexec
+Filename: "{sys}\icacls.exe";Parameters: """{app}\ThinBridge.exe"" /inheritance:r"; Flags: runhidden shellexec
+Filename: "{sys}\icacls.exe";Parameters: """{app}\ThinBridgeSetting.exe"" /inheritance:r"; Flags: runhidden shellexec
+Filename: "{sys}\icacls.exe";Parameters: """{app}\ThinBridgeChecker.exe"" /inheritance:r"; Flags: runhidden shellexec
+Filename: "{sys}\icacls.exe";Parameters: """{app}\ThinBridgeRuleUpdater.exe"" /inheritance:r"; Flags: runhidden shellexec
+Filename: "{sys}\icacls.exe";Parameters: """{app}\ThinBridgeRuleUpdaterSetting.exe"" /inheritance:r"; Flags: runhidden shellexec
+Filename: "{sys}\icacls.exe";Parameters: """{app}\ThinBridgeBHO.dll"" /inheritance:r"; Flags: runhidden shellexec
+Filename: "{sys}\icacls.exe";Parameters: """{app}\ThinBridgeBHO64.dll"" /inheritance:r"; Flags: runhidden shellexec
+Filename: "{sys}\icacls.exe";Parameters: """{app}\ThinBridgeHost\ThinBridgeTalk.exe"" /inheritance:r"; Flags: runhidden shellexec
+Filename: "{sys}\icacls.exe";Parameters: """{app}\ThinBridgeHost\edge.json"" /inheritance:r"; Flags: runhidden shellexec
+Filename: "{sys}\icacls.exe";Parameters: """{app}\ThinBridgeHost\firefox.json"" /inheritance:r"; Flags: runhidden shellexec
+Filename: "{sys}\icacls.exe";Parameters: """{app}\ThinBridgeHost\chrome.json"" /inheritance:r"; Flags: runhidden shellexec
+
+[UninstallRun]
+
+[Code]
+function GetProgramFiles(Param: string): string;
+  begin
+    if IsWin64 then Result := ExpandConstant('{pf64}')
+    else Result := ExpandConstant('{pf32}')
+  end;
+
+procedure TaskKill(FileName: String);
+var
+  ResultCode: Integer;
+begin
+    Exec(ExpandConstant('taskkill.exe'), '/f /im ' + '"' + FileName + '"', '', SW_HIDE,ewWaitUntilTerminated, ResultCode);
+end;
+function InitializeSetup():Boolean;
+begin 
+	TaskKill('iexplore.exe');
+	TaskKill('msedge.exe');
+	TaskKill('TBRedirector.exe');
+	TaskKill('ThinBridge.exe');
+	TaskKill('ThinBridgeSetting.exe');
+	TaskKill('ThinBridgeChecker.exe');
+	TaskKill('ThinBridgeRuleUpdater.exe');
+	TaskKill('ThinBridgeRuleUpdaterSetting.exe');
+	Result := True; 
+end; 
+
+function GetEdgeExtensionIndex(Value: string):string;
+var
+  Names: TArrayOfString;
+  I: Integer;
+  sIndex: String;
+	sValue:String;
+	iMax:Integer;
+	iTemp:Integer;
+begin
+	iMax :=168;
+  if RegGetValueNames(HKLM, 'SOFTWARE\Policies\Microsoft\Edge\ExtensionInstallForcelist', Names) then
+  begin
+    sIndex := '';
+		iMax :=iMax-1;
+		iTemp :=0;
+    for I := 0 to GetArrayLength(Names)-1 do
+		begin
+      sIndex := Names[I];
+			if(sIndex<>'') then
+			begin
+				RegQueryStringValue(HKLM,'SOFTWARE\Policies\Microsoft\Edge\ExtensionInstallForcelist',sIndex,sValue);
+        if(sValue='famoofbkcpjdkihdngnhgbdfkfenhcnf')then
+				begin
+				  Result:=sIndex;
+				  exit;
+				end	else
+				begin
+					iTemp := StrToInt(sIndex);
+					if(iTemp > iMax) then
+						iMax := iTemp;
+				end;
+			end;
+		end;
+		iMax := iMax +1;
+    //MsgBox('List of subkeys:'#13#10#13#10 + IntToStr(iMax), mbInformation, MB_OK);
+  end;
+	Result:=IntToStr(iMax);
+end;	


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A.

# What this PR does / why we need it:

Currently we need to update version number of each modules respectively, it's too bother.
It's convenient to add a script to update all version numbers.

In addition, we should apply same version number to each modules in future releases to avoid confusion.

It's based on @yashirot's work in https://gitlab.com/clear-code/browserselector/-/tree/e64d416a8fff577068783d2a9782a9caebdb5c8f/script

# How to verify the fixed issue:

Run the script then check `git diff` to verify that the script expectedly replace version numbers.

## The steps to verify:

1. Open PowerShell window (or something similar) at the script folder
2. Run ` powershell.exe -ExecutionPolicy Bypass -file .\ThinBridgeVersionUp.ps1 4.2.1.0`
3. Check `git diff`
4. Run unit test: `powershell.exe -ExecutionPolicy Bypass Invoke-Pester`

## Expected result:

> 3. Check `git diff`

Version numbers are replaced with `4.2.1.0`

> 4. Run unit test: `powershell.exe -ExecutionPolicy Bypass Invoke-Pester`

Pass all tests
