### PR TITLE
Fix exclude groups behavior (and more)

### DIFF
--- a/webextensions/Makefile
+++ b/webextensions/Makefile
@@ -8,15 +8,18 @@ all: packages
 testee:
 	mkdir $@
 
+testee/chrome.js: edge/background.js testee
+	sed -e "s/ThinBridgeTalkClient.init();/exports.client = ThinBridgeTalkClient/g" -e "s/ResourceCap.init();//g" chrome/background.js > $@
+
 testee/edge.js: edge/background.js testee
 	sed -e "s/ThinBridgeTalkClient.init();/exports.client = ThinBridgeTalkClient/g" -e "s/ResourceCap.init();//g" edge/background.js > $@
 
-unittest: install_dependency testee/edge.js
+unittest: install_dependency testee/chrome.js testee/edge.js
 	npx mocha --require mocha-suppress-logs test
 
 test: unittest
 
-test-verbose: install_dependency testee/edge.js
+test-verbose: install_dependency testee/chrome.js testee/edge.js
 	npx mocha test
 
 clean:

--- a/webextensions/chrome/background.js
+++ b/webextensions/chrome/background.js
@@ -99,11 +99,12 @@ const ThinBridgeTalkClient = {
   },
 
   async ensureLoadedAndConfigured() {
-    return Promise.all([
+    return this._promisedLoadedAndConfigured = this._promisedLoadedAndConfigured || Promise.all([
       !this.cached && this.configure(),
       this.load(),
     ]);
   },
+  _promisedLoadedAndConfigured: null,
 
   async configure() {
     const query = new String('C ' + BROWSER);

--- a/webextensions/chrome/background.js
+++ b/webextensions/chrome/background.js
@@ -480,7 +480,8 @@ const ThinBridgeTalkClient = {
       return;
     }
 
-    if (details.tabId < 0) {
+    if (details.tabId < 0 ||
+        details.documentLifecycle == 'prerender') {
       console.log(`* Ignore internal request`);
       return;
     }

--- a/webextensions/chrome/background.js
+++ b/webextensions/chrome/background.js
@@ -205,7 +205,10 @@ const ThinBridgeTalkClient = {
       //console.log(`* Referring exclude group ${name}: ${JSON.stringify(foreignSection && foreignSection.Patterns)}`);
       if (!foreignSection)
         continue;
-      for (const pattern of foreignSection.Patterns) {
+      for (let pattern of (foreignSection.URLPatterns || foreignSection.Patterns || [])) {
+        if (Array.isArray(pattern)) {
+          pattern = pattern[0];
+        }
         if (wildcmp(pattern, url)) {
           console.log(`* Match Exclude ${section.Name} (referring ${name}) [${pattern}]`);
           return false;
@@ -213,14 +216,20 @@ const ThinBridgeTalkClient = {
       }
     }
 
-    for (const pattern of section.Excludes) {
+    for (let pattern of (section.URLExcludePatterns || section.Excludes || [])) {
+      if (Array.isArray(pattern)) {
+        pattern = pattern[0];
+      }
       if (wildcmp(pattern, url)) {
         console.log(`* Match Exclude ${section.Name} [${pattern}]`);
         return false;
       }
     }
 
-    for (const pattern of section.Patterns) {
+    for (let pattern of (section.URLPatterns || section.Patterns || [])) {
+      if (Array.isArray(pattern)) {
+        pattern = pattern[0];
+      }
       if (wildcmp(pattern, url)) {
         console.log(`* Match ${section.Name} [${pattern}]`);
         return true;

--- a/webextensions/chrome/background.js
+++ b/webextensions/chrome/background.js
@@ -115,7 +115,7 @@ const ThinBridgeTalkClient = {
     }
     const isStartup = (this.cached == null);
     this.cached = resp.config;
-    this.cached.NamedSections = Object.fromEntries(resp.config.Sections.map(section => [section.Name, section]));
+    this.cached.NamedSections = Object.fromEntries(resp.config.Sections.map(section => [section.Name.toLowerCase(), section]));
     console.log('Fetch config', JSON.stringify(this.cached));
 
     if (isStartup && !this.resumed) {
@@ -202,7 +202,7 @@ const ThinBridgeTalkClient = {
   match(section, url, namedSections) {
     for (const name of (section.ExcludeGroups || [])) {
       const foreignSection = namedSections[name.toLowerCase()];
-      //console.log(`* Referring exclude group ${name}: ${JSON.stringify(foreignSection && foreignSection.Patterns)}`);
+      //console.log(`* Referring exclude group ${name}: ${JSON.stringify(foreignSection && (foreignSection.URLPatterns || foreignSection.Patterns))}`);
       if (!foreignSection)
         continue;
       for (let pattern of (foreignSection.URLPatterns || foreignSection.Patterns || [])) {

--- a/webextensions/edge/background.js
+++ b/webextensions/edge/background.js
@@ -99,11 +99,12 @@ const ThinBridgeTalkClient = {
   },
 
   async ensureLoadedAndConfigured() {
-    return Promise.all([
+    return this._promisedLoadedAndConfigured = this._promisedLoadedAndConfigured || Promise.all([
       !this.cached && this.configure(),
       this.load(),
     ]);
   },
+  _promisedLoadedAndConfigured: null,
 
   async configure() {
     const query = new String('C ' + BROWSER);

--- a/webextensions/edge/background.js
+++ b/webextensions/edge/background.js
@@ -480,7 +480,8 @@ const ThinBridgeTalkClient = {
       return;
     }
 
-    if (details.tabId < 0) {
+    if (details.tabId < 0 ||
+        details.documentLifecycle == 'prerender') {
       console.log(`* Ignore internal request`);
       return;
     }

--- a/webextensions/edge/background.js
+++ b/webextensions/edge/background.js
@@ -205,7 +205,10 @@ const ThinBridgeTalkClient = {
       //console.log(`* Referring exclude group ${name}: ${JSON.stringify(foreignSection && foreignSection.Patterns)}`);
       if (!foreignSection)
         continue;
-      for (const pattern of foreignSection.Patterns) {
+      for (let pattern of (foreignSection.URLPatterns || foreignSection.Patterns || [])) {
+        if (Array.isArray(pattern)) {
+          pattern = pattern[0];
+        }
         if (wildcmp(pattern, url)) {
           console.log(`* Match Exclude ${section.Name} (referring ${name}) [${pattern}]`);
           return false;
@@ -213,14 +216,20 @@ const ThinBridgeTalkClient = {
       }
     }
 
-    for (const pattern of section.Excludes) {
+    for (let pattern of (section.URLExcludePatterns || section.Excludes || [])) {
+      if (Array.isArray(pattern)) {
+        pattern = pattern[0];
+      }
       if (wildcmp(pattern, url)) {
         console.log(`* Match Exclude ${section.Name} [${pattern}]`);
         return false;
       }
     }
 
-    for (const pattern of section.Patterns) {
+    for (let pattern of (section.URLPatterns || section.Patterns || [])) {
+      if (Array.isArray(pattern)) {
+        pattern = pattern[0];
+      }
       if (wildcmp(pattern, url)) {
         console.log(`* Match ${section.Name} [${pattern}]`);
         return true;

--- a/webextensions/edge/background.js
+++ b/webextensions/edge/background.js
@@ -115,7 +115,7 @@ const ThinBridgeTalkClient = {
     }
     const isStartup = (this.cached == null);
     this.cached = resp.config;
-    this.cached.NamedSections = Object.fromEntries(resp.config.Sections.map(section => [section.Name, section]));
+    this.cached.NamedSections = Object.fromEntries(resp.config.Sections.map(section => [section.Name.toLowerCase(), section]));
     console.log('Fetch config', JSON.stringify(this.cached));
 
     if (isStartup && !this.resumed) {
@@ -202,7 +202,7 @@ const ThinBridgeTalkClient = {
   match(section, url, namedSections) {
     for (const name of (section.ExcludeGroups || [])) {
       const foreignSection = namedSections[name.toLowerCase()];
-      //console.log(`* Referring exclude group ${name}: ${JSON.stringify(foreignSection && foreignSection.Patterns)}`);
+      //console.log(`* Referring exclude group ${name}: ${JSON.stringify(foreignSection && (foreignSection.URLPatterns || foreignSection.Patterns))}`);
       if (!foreignSection)
         continue;
       for (let pattern of (foreignSection.URLPatterns || foreignSection.Patterns || [])) {

--- a/webextensions/firefox/background.js
+++ b/webextensions/firefox/background.js
@@ -385,7 +385,8 @@ const ThinBridgeTalkClient = {
       return;
     }
 
-    if (details.tabId < 0) {
+    if (details.tabId < 0 ||
+        details.documentLifecycle == 'prerender') {
       console.log(`* Ignore internal request`);
       return;
     }

--- a/webextensions/firefox/background.js
+++ b/webextensions/firefox/background.js
@@ -93,7 +93,7 @@ const ThinBridgeTalkClient = {
       }
       const isStartup = (this.cached == null);
       this.cached = resp.config;
-      this.cached.NamedSections = Object.fromEntries(resp.config.Sections.map(section => [section.Name, section]));
+      this.cached.NamedSections = Object.fromEntries(resp.config.Sections.map(section => [section.Name.toLowerCase(), section]));
       console.log('Fetch config', JSON.stringify(this.cached));
 
       if (isStartup) {
@@ -173,7 +173,7 @@ const ThinBridgeTalkClient = {
   match(section, url, namedSections) {
     for (const name of (section.ExcludeGroups || [])) {
       const foreignSection = namedSections[name.toLowerCase()];
-      //console.log(`* Referring exclude group ${name}: ${JSON.stringify(foreignSection && foreignSection.Patterns)}`);
+      //console.log(`* Referring exclude group ${name}: ${JSON.stringify(foreignSection && (foreignSection.URLPatterns || foreignSection.Patterns))}`);
       if (!foreignSection)
         continue;
       for (let pattern of (foreignSection.URLPatterns || foreignSection.Patterns || [])) {

--- a/webextensions/firefox/background.js
+++ b/webextensions/firefox/background.js
@@ -176,7 +176,10 @@ const ThinBridgeTalkClient = {
       //console.log(`* Referring exclude group ${name}: ${JSON.stringify(foreignSection && foreignSection.Patterns)}`);
       if (!foreignSection)
         continue;
-      for (const pattern of foreignSection.Patterns) {
+      for (let pattern of (foreignSection.URLPatterns || foreignSection.Patterns || [])) {
+        if (Array.isArray(pattern)) {
+          pattern = pattern[0];
+        }
         if (wildcmp(pattern, url)) {
           console.log(`* Match Exclude ${section.Name} (referring ${name}) [${pattern}]`);
           return false;
@@ -184,14 +187,20 @@ const ThinBridgeTalkClient = {
       }
     }
 
-    for (const pattern of section.Excludes) {
+    for (let pattern of (section.URLExcludePatterns || section.Excludes || [])) {
+      if (Array.isArray(pattern)) {
+        pattern = pattern[0];
+      }
       if (wildcmp(pattern, url)) {
         console.log(`* Match Exclude ${section.Name} [${pattern}]`);
         return false;
       }
     }
 
-    for (const pattern of section.Patterns) {
+    for (let pattern of (section.URLPatterns || section.Patterns || [])) {
+      if (Array.isArray(pattern)) {
+        pattern = pattern[0];
+      }
       if (wildcmp(pattern, url)) {
         console.log(`* Match ${section.Name} [${pattern}]`);
         return true;

--- a/webextensions/test/test-redirect-interval-limit.js
+++ b/webextensions/test/test-redirect-interval-limit.js
@@ -1,0 +1,56 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const chromestub = require('./chrome-stub.js')
+
+describe('checkRedirectIntervalLimit', () => {
+  const redirectors = [
+    { browser: 'chrome', module: require('../testee/chrome.js') },
+    { browser: 'edge',   module: require('../testee/edge.js')   },
+  ].forEach(({browser, module}) => {
+    describe(browser, () => {
+      const thinbridge = module.client;
+      const tabId = 123;
+      let clock;
+
+      beforeEach(() => {
+        clock = sinon.useFakeTimers();
+        thinbridge.recentRequests = {};
+      });
+
+      afterEach(() => {
+        delete thinbridge.recentRequests;
+        clock.restore();
+      });
+
+      it('allow first request', () => {
+        const url = "https://www.google.com/";
+        const ret = thinbridge.checkRedirectIntervalLimit(tabId, url);
+        assert.equal(ret, false);
+      });
+
+      it('skip frequent same request', () => {
+        const url = "https://www.google.com/";
+        const ret1 = thinbridge.checkRedirectIntervalLimit(tabId, url);
+        clock.tick(300);
+        const ret2 = thinbridge.checkRedirectIntervalLimit(tabId, url);
+        assert.deepEqual({ ret1: !!ret1, ret2: !!ret2 }, { ret1: false, ret2: true });
+      });
+
+      it('allow same request after 1 sec', () => {
+        const url = "https://www.google.com/";
+        const ret1 = thinbridge.checkRedirectIntervalLimit(tabId, url);
+        clock.tick(1001);
+        const ret2 = thinbridge.checkRedirectIntervalLimit(tabId, url);
+        assert.deepEqual({ ret1: !!ret1, ret2: !!ret2 }, { ret1: false, ret2: false });
+      });
+
+      it('allow same request in different tab', () => {
+        const url = "https://www.google.com/";
+        const ret1 = thinbridge.checkRedirectIntervalLimit(tabId, url);
+        clock.tick(300);
+        const ret2 = thinbridge.checkRedirectIntervalLimit(tabId + 1, url);
+        assert.deepEqual({ ret1: !!ret1, ret2: !!ret2 }, { ret1: false, ret2: false });
+      });
+    });
+  });
+});

--- a/webextensions/test/test-redirect-rule.js
+++ b/webextensions/test/test-redirect-rule.js
@@ -1,276 +1,276 @@
 const assert = require('assert');
 const sinon = require('sinon');
 const chromestub = require('./chrome-stub.js')
-const edge = require('../testee/edge.js');
 
-describe('Microsoft Edge Add-on', () => {
-  const isClosableTab = true;
-  const tabId = 123;
-  const shouldCloseTab = true;
-  const baseConfig = {
-    CloseEmptyTab: 1,
-    DefaultBrowser: "Chrome",
-    IgnoreQueryString: 1,
-    OnlyMainFrame : 1,
-    Sections: [],
-  }
-  const citrixSection = {
-    "Name": "citrix",
-    "Patterns": ["https://www.google.com/*"],
-    "Excludes": [],
-  };
-  const edgeSection = { // should not redirect since it's me
-    "Name": "edge",
-    "Patterns": ["https://www.microsoft.com/*"],
-    "Excludes": [],
-  };
-  const chromeSection = {
-    "Name": "chrome",
-    "Patterns": ["*://*"],
-    "Excludes": [],
-  };
-  const custom18Section = {  // a.k.a DMZ section, should not redirect
-    "Name": "custom18",
-    "Patterns": ["https://www.example.com/*"],
-    "Excludes": [],
-  };
-  const queryTestSection = {
-    "Name": "firefox",
-    "Patterns": ["https://www.google.com/search"],
-    "Excludes": [],
-  };
+describe('Redirect rule', () => {
+  const redirectors = [
+    { browser: 'edge',   module: require('../testee/edge.js')   },
+  ].forEach(({browser, module}) => {
+    describe(browser, () => {
+      const isClosableTab = true;
+      const tabId = 123;
+      const shouldCloseTab = true;
+      const baseConfig = {
+        CloseEmptyTab: 1,
+        DefaultBrowser: "Chrome",
+        IgnoreQueryString: 1,
+        OnlyMainFrame : 1,
+        Sections: [],
+      }
+      const edgeSection = { // should not redirect since it's me
+        "Name": "edge",
+        "Patterns": ["https://www.clear-code.com/*"],
+        "Excludes": [],
+      };
+      const chromeSection = {
+        "Name": "chrome",
+        "Patterns": ["*://*"],
+        "Excludes": [],
+      };
+      const custom18Section = {  // a.k.a DMZ section, should not redirect
+        "Name": "custom18",
+        "Patterns": ["https://www.example.com/*"],
+        "Excludes": [],
+      };
+      const queryTestSection = {
+        "Name": "firefox",
+        "Patterns": ["https://www.google.com/search"],
+        "Excludes": [],
+      };
 
-  function config(sections = [], additionals = {}) {
-    const config = {...baseConfig, ...additionals};
-    config.Sections = [...config.Sections, ...sections];
-    config.NamedSections = Object.fromEntries(config.Sections.map(section => [section.Name, section]));
-    return config;
-  }
+      function config(sections = [], additionals = {}) {
+        const config = {...baseConfig, ...additionals};
+        config.Sections = [...config.Sections, ...sections];
+        config.NamedSections = Object.fromEntries(config.Sections.map(section => [section.Name, section]));
+        return config;
+      }
 
 
-  const thinbridge = edge.client;
-  let thinbridge_mock;
+      const thinbridge = module.client;
+      let thinbridge_mock;
 
-  beforeEach(() => {
-    thinbridge_mock = sinon.mock(thinbridge);
-  });
+      beforeEach(() => {
+        thinbridge_mock = sinon.mock(thinbridge);
+      });
 
-  afterEach(() => {
-    thinbridge_mock.restore();
-  });
-
-
-  //
-  // * redirect rule: compatible mode
-  //   This mode is for common usage and should be compatible with v1.x
-  //   especially v1.4.0 which is ManifestV2 version of this add-on.
-  //   v1.4.0 was the latest version of public v1.x releases, v1.5.0 isn't
-  //   published.
-  //
-  describe('redirect rule: compatible mode', () => {
-
-    it('redirect no match URL', () => {
-      const url = "https://www.google.com/";
-      const conf = config();
-      thinbridge_mock.expects("redirect").once().withArgs(url, tabId, shouldCloseTab);
-      const shouldBlock = thinbridge.handleURLAndBlock(conf, tabId, url, isClosableTab);
-      thinbridge_mock.verify();
-      assert.equal(shouldBlock, true);
-    });
-
-    it('load no match URL with no default browser', () => {
-      const url = "https://www.google.com/";
-      const conf = config([], { DefaultBrowser: "" });
-      thinbridge_mock.expects("redirect").never();
-      const shouldBlock = thinbridge.handleURLAndBlock(conf, tabId, url, isClosableTab);
-      thinbridge_mock.verify();
-      assert.equal(shouldBlock, false);
-    });
-
-    it('redirect matched URL', () => {
-      const url = "https://www.google.com/";
-      const conf = config([chromeSection])
-      thinbridge_mock.expects("redirect").once().withArgs(url, tabId, shouldCloseTab);
-      const shouldBlock = thinbridge.handleURLAndBlock(conf, tabId, url, isClosableTab);
-      thinbridge_mock.verify();
-      assert.equal(shouldBlock, true);
-    });
-
-    it('redirect URL matched to one of patterns', () => {
-      const url = "https://www.example.com/";
-      const conf = config(
-        [{
-          "Name": "chrome",
-          "Patterns": [
-            "https://www.google.com/*",
-            "https://www.microsoft.com/*",
-            "https://www.example.com/*",
-          ],
-          "Excludes": [],
-        }]
-      )
-      thinbridge_mock.expects("redirect").once().withArgs(url, tabId, shouldCloseTab);
-      const shouldBlock = thinbridge.handleURLAndBlock(conf, tabId, url, isClosableTab);
-      thinbridge_mock.verify();
-      assert.equal(shouldBlock, true);
-    });
-
-    it('do not close tab with CloseEmptyTab option', () => {
-      const url = "https://www.google.com/";
-      const conf = config([chromeSection], { CloseEmptyTab: false })
-      thinbridge_mock.expects("redirect").once().withArgs(url, tabId, !shouldCloseTab);
-      const shouldBlock = thinbridge.handleURLAndBlock(conf, tabId, url, isClosableTab);
-      thinbridge_mock.verify();
-      assert.equal(shouldBlock, true);
-    });
-
-    it('do not close non-closable tab', () => {
-      const url = "https://www.google.com/";
-      const conf = config([chromeSection])
-      thinbridge_mock.expects("redirect").once().withArgs(url, tabId, !shouldCloseTab);
-      const shouldBlock = thinbridge.handleURLAndBlock(conf, tabId, url, !isClosableTab);
-      thinbridge_mock.verify();
-      assert.equal(shouldBlock, true);
-    });
-
-    it('load URL matched to custom18', () => {
-      const url = "https://www.example.com/";
-      const conf = config([custom18Section])
-      thinbridge_mock.expects("redirect").never()
-      const shouldBlock = thinbridge.handleURLAndBlock(conf, 0, url, isClosableTab);
-      thinbridge_mock.verify();
-      assert.equal(shouldBlock, false);
-    });
-
-    it('treat custom18 prior than others', () => {
-      const url = "https://www.example.com/";
-      const conf = config([chromeSection, custom18Section])
-      thinbridge_mock.expects("redirect").never()
-      const shouldBlock = thinbridge.handleURLAndBlock(conf, 0, url, isClosableTab);
-      thinbridge_mock.verify();
-      assert.equal(shouldBlock, false);
-    });
-
-    it('load URL matched to edge', () => {
-      const url = "https://www.microsoft.com/";
-      const conf = config([edgeSection])
-      thinbridge_mock.expects("redirect").never()
-      const shouldBlock = thinbridge.handleURLAndBlock(conf, 0, url, isClosableTab);
-      thinbridge_mock.verify();
-      assert.equal(shouldBlock, false);
-    });
-
-    it('treat edge prior than others', () => {
-      const url = "https://www.microsoft.com/";
-      const conf = config([chromeSection, edgeSection])
-      thinbridge_mock.expects("redirect").never()
-      const shouldBlock = thinbridge.handleURLAndBlock(conf, 0, url, isClosableTab);
-      thinbridge_mock.verify();
-      assert.equal(shouldBlock, false);
-    });
-
-    it('treat URL as unmatched to custom18, when it matched to exclude pattern', () => {
-      const url = "https://www.example.com/index.html";
-      const conf = config([custom18Section])
-      conf.Sections[0].Excludes = [url]
-      thinbridge_mock.expects("redirect").once().withArgs(url, tabId, shouldCloseTab);
-      const shouldBlock = thinbridge.handleURLAndBlock(conf, tabId, url, isClosableTab);
-      thinbridge_mock.verify();
-      assert.equal(shouldBlock, true);
-    });
-
-    it('treat URL as unmatched to custom18, when it matched to one of multiple exclude patterns', () => {
-      const url = "https://www.example.com/";
-      const conf = config(
-        [{
-          "Name": "custom18",
-          "Patterns": ["*"],
-          "Excludes": [
-            "https://www.google.com/*",
-            "https://www.microsoft.com/*",
-            "https://www.example.com/*",
-          ],
-        }]
-      );
-      thinbridge_mock.expects("redirect").once().withArgs(url, tabId, shouldCloseTab);
-      const shouldBlock = thinbridge.handleURLAndBlock(conf, tabId, url, isClosableTab);
-      thinbridge_mock.verify();
-      assert.equal(shouldBlock, true);
-    });
-
-    it('preserve query for redirection', () => {
-      const conf = config([citrixSection]);
-      const url = "https://www.google.com/search?q=foobar";
-      thinbridge_mock.expects("redirect").once().withArgs(url, tabId, shouldCloseTab);
-      const shouldBlock = thinbridge.handleURLAndBlock(conf, tabId, url, isClosableTab);
-      thinbridge_mock.verify();
-      assert.equal(shouldBlock, true);
-    });
-
-    it('ignore URL query when matching with IgnoreQueryString=1', () => {
-      const url = "https://www.google.com/search?q=hoge";
-      const conf = config([queryTestSection], { DefaultBrowser: "" })
-      thinbridge_mock.expects("redirect").once().withArgs(url, tabId, shouldCloseTab);
-      const shouldBlock = thinbridge.handleURLAndBlock(conf, tabId, url, isClosableTab);
-      thinbridge_mock.verify();
-      assert.equal(shouldBlock, true);
-    });
-
-    it('regard URL query when matching with IgnoreQueryString=0', () => {
-      const url = "https://www.google.com/search?q=hoge";
-      const conf = config([queryTestSection], { DefaultBrowser: "", IgnoreQueryString: 0 })
-      thinbridge_mock.expects("redirect").never();
-      const shouldBlock = thinbridge.handleURLAndBlock(conf, tabId, url, isClosableTab);
-      thinbridge_mock.verify();
-      assert.equal(shouldBlock, false);
-    });
-  });
+      afterEach(() => {
+        thinbridge_mock.restore();
+      });
 
 
-  //
-  // * redirect rule: action mode
-  //   This mode is for a perticular usage, not for public.
-  //
-  describe('redirect rule: action mode', () => {
+      //
+      // * redirect rule: compatible mode
+      //   This mode is for common usage and should be compatible with v1.x
+      //   especially v1.4.0 which is ManifestV2 version of this add-on.
+      //   v1.4.0 was the latest version of public v1.x releases, v1.5.0 isn't
+      //   published.
+      //
+      describe('compatible mode', () => {
 
-    it('override default redirect action to load', () => {
-      const url = "https://www.google.com/";
-      const conf = config([{...chromeSection}]);
-      conf.Sections[0].Action = "load";
-      thinbridge_mock.expects("redirect").never();
-      const shouldBlock = thinbridge.handleURLAndBlock(conf, tabId, url, isClosableTab);
-      thinbridge_mock.verify();
-      assert.equal(shouldBlock, false);
-    });
+        it('redirect no match URL', () => {
+          const url = "https://www.google.com/";
+          const conf = config();
+          thinbridge_mock.expects("redirect").once().withArgs(url, tabId, shouldCloseTab);
+          const shouldBlock = thinbridge.handleURLAndBlock(conf, tabId, url, isClosableTab);
+          thinbridge_mock.verify();
+          assert.equal(shouldBlock, true);
+        });
 
-    it('override default load action to redirect', () => {
-      const url = "https://www.microsoft.com/";
-      const conf = config([{...edgeSection}]);
-      conf.Sections[0].Action = "redirect";
-      thinbridge_mock.expects("redirect").once().withArgs(url, tabId, true);
-      const shouldBlock = thinbridge.handleURLAndBlock(conf, tabId, url, isClosableTab);
-      thinbridge_mock.verify();
-      assert.equal(shouldBlock, true);
-    });
+        it('load no match URL with no default browser', () => {
+          const url = "https://www.google.com/";
+          const conf = config([], { DefaultBrowser: "" });
+          thinbridge_mock.expects("redirect").never();
+          const shouldBlock = thinbridge.handleURLAndBlock(conf, tabId, url, isClosableTab);
+          thinbridge_mock.verify();
+          assert.equal(shouldBlock, false);
+        });
 
-    it('set default redirect action explicitly', () => {
-      const url = "https://www.google.com/";
-      const conf = config([{...chromeSection}]);
-      conf.Sections[0].Action = "redirect";
-      thinbridge_mock.expects("redirect").once().withArgs(url, tabId, true);
-      const shouldBlock = thinbridge.handleURLAndBlock(conf, tabId, url, isClosableTab);
-      thinbridge_mock.verify();
-      assert.equal(shouldBlock, true);
-    });
+        it('redirect matched URL', () => {
+          const url = "https://www.google.com/";
+          const conf = config([chromeSection])
+          thinbridge_mock.expects("redirect").once().withArgs(url, tabId, shouldCloseTab);
+          const shouldBlock = thinbridge.handleURLAndBlock(conf, tabId, url, isClosableTab);
+          thinbridge_mock.verify();
+          assert.equal(shouldBlock, true);
+        });
 
-    it('set default load action explicitly', () => {
-      const url = "https://www.microsoft.com/";
-      const conf = config([{...edgeSection}]);
-      conf.Sections[0].Action = "load";
-      thinbridge_mock.expects("redirect").never();
-      const shouldBlock = thinbridge.handleURLAndBlock(conf, tabId, url, isClosableTab);
-      thinbridge_mock.verify();
-      assert.equal(shouldBlock, false);
+        it('redirect URL matched to one of patterns', () => {
+          const url = "https://www.example.com/";
+          const conf = config(
+            [{
+              "Name": "chrome",
+              "Patterns": [
+                "https://www.google.com/*",
+                "https://www.clear-code.com/*",
+                "https://www.example.com/*",
+              ],
+              "Excludes": [],
+            }]
+          )
+          thinbridge_mock.expects("redirect").once().withArgs(url, tabId, shouldCloseTab);
+          const shouldBlock = thinbridge.handleURLAndBlock(conf, tabId, url, isClosableTab);
+          thinbridge_mock.verify();
+          assert.equal(shouldBlock, true);
+        });
+
+        it('do not close tab with CloseEmptyTab option', () => {
+          const url = "https://www.google.com/";
+          const conf = config([chromeSection], { CloseEmptyTab: false })
+          thinbridge_mock.expects("redirect").once().withArgs(url, tabId, !shouldCloseTab);
+          const shouldBlock = thinbridge.handleURLAndBlock(conf, tabId, url, isClosableTab);
+          thinbridge_mock.verify();
+          assert.equal(shouldBlock, true);
+        });
+
+        it('do not close non-closable tab', () => {
+          const url = "https://www.google.com/";
+          const conf = config([chromeSection])
+          thinbridge_mock.expects("redirect").once().withArgs(url, tabId, !shouldCloseTab);
+          const shouldBlock = thinbridge.handleURLAndBlock(conf, tabId, url, !isClosableTab);
+          thinbridge_mock.verify();
+          assert.equal(shouldBlock, true);
+        });
+
+        it('load URL matched to custom18', () => {
+          const url = "https://www.example.com/";
+          const conf = config([custom18Section])
+          thinbridge_mock.expects("redirect").never()
+          const shouldBlock = thinbridge.handleURLAndBlock(conf, 0, url, isClosableTab);
+          thinbridge_mock.verify();
+          assert.equal(shouldBlock, false);
+        });
+
+        it('treat custom18 prior than others', () => {
+          const url = "https://www.example.com/";
+          const conf = config([chromeSection, custom18Section])
+          thinbridge_mock.expects("redirect").never()
+          const shouldBlock = thinbridge.handleURLAndBlock(conf, 0, url, isClosableTab);
+          thinbridge_mock.verify();
+          assert.equal(shouldBlock, false);
+        });
+
+        it(`load URL matched to ${browser}`, () => {
+          const url = "https://www.clear-code.com/";
+          const conf = config([edgeSection])
+          thinbridge_mock.expects("redirect").never()
+          const shouldBlock = thinbridge.handleURLAndBlock(conf, 0, url, isClosableTab);
+          thinbridge_mock.verify();
+          assert.equal(shouldBlock, false);
+        });
+
+        it(`treat ${browser} prior than others`, () => {
+          const url = "https://www.clear-code.com/";
+          const conf = config([chromeSection, edgeSection])
+          thinbridge_mock.expects("redirect").never()
+          const shouldBlock = thinbridge.handleURLAndBlock(conf, 0, url, isClosableTab);
+          thinbridge_mock.verify();
+          assert.equal(shouldBlock, false);
+        });
+
+        it('treat URL as unmatched to custom18, when it matched to exclude pattern', () => {
+          const url = "https://www.example.com/index.html";
+          const conf = config([custom18Section])
+          conf.Sections[0].Excludes = [url]
+          thinbridge_mock.expects("redirect").once().withArgs(url, tabId, shouldCloseTab);
+          const shouldBlock = thinbridge.handleURLAndBlock(conf, tabId, url, isClosableTab);
+          thinbridge_mock.verify();
+          assert.equal(shouldBlock, true);
+        });
+
+        it('treat URL as unmatched to custom18, when it matched to one of multiple exclude patterns', () => {
+          const url = "https://www.example.com/";
+          const conf = config(
+            [{
+              "Name": "custom18",
+              "Patterns": ["*"],
+              "Excludes": [
+                "https://www.google.com/*",
+                "https://www.clear-code.com/*",
+                "https://www.example.com/*",
+              ],
+            }]
+          );
+          thinbridge_mock.expects("redirect").once().withArgs(url, tabId, shouldCloseTab);
+          const shouldBlock = thinbridge.handleURLAndBlock(conf, tabId, url, isClosableTab);
+          thinbridge_mock.verify();
+          assert.equal(shouldBlock, true);
+        });
+
+        it('preserve query for redirection', () => {
+          const conf = config([queryTestSection]);
+          const url = "https://www.google.com/search?q=foobar";
+          thinbridge_mock.expects("redirect").once().withArgs(url, tabId, shouldCloseTab);
+          const shouldBlock = thinbridge.handleURLAndBlock(conf, tabId, url, isClosableTab);
+          thinbridge_mock.verify();
+          assert.equal(shouldBlock, true);
+        });
+
+        it('ignore URL query when matching with IgnoreQueryString=1', () => {
+          const url = "https://www.google.com/search?q=hoge";
+          const conf = config([queryTestSection], { DefaultBrowser: "" })
+          thinbridge_mock.expects("redirect").once().withArgs(url, tabId, shouldCloseTab);
+          const shouldBlock = thinbridge.handleURLAndBlock(conf, tabId, url, isClosableTab);
+          thinbridge_mock.verify();
+          assert.equal(shouldBlock, true);
+        });
+
+        it('regard URL query when matching with IgnoreQueryString=0', () => {
+          const url = "https://www.google.com/search?q=hoge";
+          const conf = config([queryTestSection], { DefaultBrowser: "", IgnoreQueryString: 0 })
+          thinbridge_mock.expects("redirect").never();
+          const shouldBlock = thinbridge.handleURLAndBlock(conf, tabId, url, isClosableTab);
+          thinbridge_mock.verify();
+          assert.equal(shouldBlock, false);
+        });
+      });
+
+
+      //
+      // * redirect rule: action mode
+      //   This mode is for a perticular usage, not for public.
+      //
+      describe('action mode', () => {
+
+        it('override default redirect action to load', () => {
+          const url = "https://www.google.com/";
+          const conf = config([{...chromeSection}]);
+          conf.Sections[0].Action = "load";
+          thinbridge_mock.expects("redirect").never();
+          const shouldBlock = thinbridge.handleURLAndBlock(conf, tabId, url, isClosableTab);
+          thinbridge_mock.verify();
+          assert.equal(shouldBlock, false);
+        });
+
+        it('override default load action to redirect', () => {
+          const url = "https://www.clear-code.com/";
+          const conf = config([{...edgeSection}]);
+          conf.Sections[0].Action = "redirect";
+          thinbridge_mock.expects("redirect").once().withArgs(url, tabId, true);
+          const shouldBlock = thinbridge.handleURLAndBlock(conf, tabId, url, isClosableTab);
+          thinbridge_mock.verify();
+          assert.equal(shouldBlock, true);
+        });
+
+        it('set default redirect action explicitly', () => {
+          const url = "https://www.google.com/";
+          const conf = config([{...chromeSection}]);
+          conf.Sections[0].Action = "redirect";
+          thinbridge_mock.expects("redirect").once().withArgs(url, tabId, true);
+          const shouldBlock = thinbridge.handleURLAndBlock(conf, tabId, url, isClosableTab);
+          thinbridge_mock.verify();
+          assert.equal(shouldBlock, true);
+        });
+
+        it('set default load action explicitly', () => {
+          const url = "https://www.clear-code.com/";
+          const conf = config([{...edgeSection}]);
+          conf.Sections[0].Action = "load";
+          thinbridge_mock.expects("redirect").never();
+          const shouldBlock = thinbridge.handleURLAndBlock(conf, tabId, url, isClosableTab);
+          thinbridge_mock.verify();
+          assert.equal(shouldBlock, false);
+        });
+      });
     });
   });
 });

--- a/webextensions/test/test-redirect-rule.js
+++ b/webextensions/test/test-redirect-rule.js
@@ -273,49 +273,4 @@ describe('Microsoft Edge Add-on', () => {
       assert.equal(shouldBlock, false);
     });
   });
-
-  describe('checkRedirectIntervalLimit', () => {
-    let clock;
-
-    beforeEach(() => {
-      clock = sinon.useFakeTimers();
-      thinbridge.recentRequests = {};
-    });
-
-    afterEach(() => {
-      delete thinbridge.recentRequests;
-      clock.restore();
-    });
-
-    it('allow first request', () => {
-      const url = "https://www.google.com/";
-      const ret = thinbridge.checkRedirectIntervalLimit(tabId, url);
-      assert.equal(ret, false);
-    });
-
-    it('skip frequent same request', () => {
-      const url = "https://www.google.com/";
-      const ret1 = thinbridge.checkRedirectIntervalLimit(tabId, url);
-      clock.tick(300);
-      const ret2 = thinbridge.checkRedirectIntervalLimit(tabId, url);
-      assert.deepEqual({ ret1: !!ret1, ret2: !!ret2 }, { ret1: false, ret2: true });
-    });
-
-    it('allow same request after 1 sec', () => {
-      const url = "https://www.google.com/";
-      const ret1 = thinbridge.checkRedirectIntervalLimit(tabId, url);
-      clock.tick(1001);
-      const ret2 = thinbridge.checkRedirectIntervalLimit(tabId, url);
-      assert.deepEqual({ ret1: !!ret1, ret2: !!ret2 }, { ret1: false, ret2: false });
-    });
-
-    it('allow same request in different tab', () => {
-      const url = "https://www.google.com/";
-      const ret1 = thinbridge.checkRedirectIntervalLimit(tabId, url);
-      clock.tick(300);
-      const ret2 = thinbridge.checkRedirectIntervalLimit(tabId + 1, url);
-      assert.deepEqual({ ret1: !!ret1, ret2: !!ret2 }, { ret1: false, ret2: false });
-    });
-  });
-
 });

--- a/webextensions/test/test-redirect-rule.js
+++ b/webextensions/test/test-redirect-rule.js
@@ -32,6 +32,7 @@ describe('Redirect rule', () => {
         "Excludes": [],
       };
       const mySection = isEdge() ? edgeSection : chromeSection;
+      const counterSection = isEdge() ? chromeSection : edgeSection;
       const citrixSection = {
         "Name": "citrix",
         "Patterns": ["https://www.citrix.com/*"],
@@ -97,7 +98,7 @@ describe('Redirect rule', () => {
 
         it('redirect matched URL', () => {
           const url = "https://www.google.com/";
-          const conf = config([chromeSection])
+          const conf = config([counterSection])
           thinbridge_mock.expects("redirect").once().withArgs(url, tabId, shouldCloseTab);
           const shouldBlock = thinbridge.handleURLAndBlock(conf, tabId, url, isClosableTab);
           thinbridge_mock.verify();
@@ -125,7 +126,7 @@ describe('Redirect rule', () => {
 
         it('do not close tab with CloseEmptyTab option', () => {
           const url = "https://www.google.com/";
-          const conf = config([chromeSection], { CloseEmptyTab: false })
+          const conf = config([counterSection], { CloseEmptyTab: false })
           thinbridge_mock.expects("redirect").once().withArgs(url, tabId, !shouldCloseTab);
           const shouldBlock = thinbridge.handleURLAndBlock(conf, tabId, url, isClosableTab);
           thinbridge_mock.verify();
@@ -134,7 +135,7 @@ describe('Redirect rule', () => {
 
         it('do not close non-closable tab', () => {
           const url = "https://www.google.com/";
-          const conf = config([chromeSection])
+          const conf = config([counterSection])
           thinbridge_mock.expects("redirect").once().withArgs(url, tabId, !shouldCloseTab);
           const shouldBlock = thinbridge.handleURLAndBlock(conf, tabId, url, !isClosableTab);
           thinbridge_mock.verify();
@@ -152,7 +153,7 @@ describe('Redirect rule', () => {
 
         it('treat custom18 prior than others', () => {
           const url = "https://www.example.com/";
-          const conf = config([chromeSection, custom18Section])
+          const conf = config([counterSection, custom18Section])
           thinbridge_mock.expects("redirect").never()
           const shouldBlock = thinbridge.handleURLAndBlock(conf, 0, url, isClosableTab);
           thinbridge_mock.verify();

--- a/webextensions/test/test-redirect-rule.js
+++ b/webextensions/test/test-redirect-rule.js
@@ -31,6 +31,7 @@ describe('Redirect rule', () => {
         "Patterns": [isEdge() ? "*://*" : "https://www.clear-code.com/*"],
         "Excludes": [],
       };
+      const mySection = isEdge() ? edgeSection : chromeSection;
       const citrixSection = {
         "Name": "citrix",
         "Patterns": ["https://www.citrix.com/*"],
@@ -160,7 +161,7 @@ describe('Redirect rule', () => {
 
         it(`load URL matched to ${browser}`, () => {
           const url = "https://www.clear-code.com/";
-          const conf = config([isEdge() ? edgeSection : chromeSection])
+          const conf = config([mySection])
           thinbridge_mock.expects("redirect").never()
           const shouldBlock = thinbridge.handleURLAndBlock(conf, 0, url, isClosableTab);
           thinbridge_mock.verify();
@@ -270,7 +271,7 @@ describe('Redirect rule', () => {
 
         it('override default load action to redirect', () => {
           const url = "https://www.clear-code.com/";
-          const conf = config([{...(isEdge() ? edgeSection : chromeSection)}]);
+          const conf = config([mySection]);
           conf.Sections[0].Action = "redirect";
           thinbridge_mock.expects("redirect").once().withArgs(url, tabId, true);
           const shouldBlock = thinbridge.handleURLAndBlock(conf, tabId, url, isClosableTab);
@@ -279,8 +280,8 @@ describe('Redirect rule', () => {
         });
 
         it('set default redirect action explicitly', () => {
-          const url = "https://www.google.com/";
-          const conf = config([{...(isEdge() ? chromeSection : edgeSection)}]);
+          const url = "https://www.citrix.com/";
+          const conf = config([{...citrixSection}]);
           conf.Sections[0].Action = "redirect";
           thinbridge_mock.expects("redirect").once().withArgs(url, tabId, true);
           const shouldBlock = thinbridge.handleURLAndBlock(conf, tabId, url, isClosableTab);
@@ -290,7 +291,7 @@ describe('Redirect rule', () => {
 
         it('set default load action explicitly', () => {
           const url = "https://www.clear-code.com/";
-          const conf = config([{...(isEdge() ? edgeSection : chromeSection)}]);
+          const conf = config([mySection]);
           conf.Sections[0].Action = "load";
           thinbridge_mock.expects("redirect").never();
           const shouldBlock = thinbridge.handleURLAndBlock(conf, tabId, url, isClosableTab);

--- a/webextensions/test/test-redirect-rule.js
+++ b/webextensions/test/test-redirect-rule.js
@@ -205,6 +205,24 @@ describe('Redirect rule', () => {
           assert.equal(shouldBlock, true);
         });
 
+        it('treat URL as unmatched to custom18, when it matched to an exclude group', () => {
+          const url = "https://www.citrix.com/";
+          const conf = config(
+            [
+              {
+                "Name": "custom18",
+                "Patterns": ["*"],
+                "ExcludeGroups": ["Citrix"],
+              },
+              citrixSection,
+            ]
+          );
+          thinbridge_mock.expects("redirect").once().withArgs(url, tabId, shouldCloseTab);
+          const shouldBlock = thinbridge.handleURLAndBlock(conf, tabId, url, isClosableTab);
+          thinbridge_mock.verify();
+          assert.equal(shouldBlock, true);
+        });
+
         it('preserve query for redirection', () => {
           const conf = config([queryTestSection]);
           const url = "https://www.google.com/search?q=foobar";


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

This PR backports changes done in [IE View WE MV3](https://github.com/clear-code/ieview-we/pull/56).

* Process `@EXCLUDE_GROUP` directive correctly.
* Prevent redirecting requests for preloading.
* Prevent multiple times calling of the native messaging host at the startup.

# How to verify the fixed issue:

See the pre-release verification manual.