### PR TITLE
Avoid duplicate redirection on startup

### DIFF
--- a/webextensions/Makefile
+++ b/webextensions/Makefile
@@ -6,7 +6,7 @@ NPM_BIN_DIR := $(NPM_MOD_DIR)/.bin
 all: packages
 
 testee:
-	mkdir -p $@
+	mkdir $@
 
 testee/chrome.js: edge/background.js testee
 	sed -e "s/ThinBridgeTalkClient.init();/exports.client = ThinBridgeTalkClient/g" -e "s/ResourceCap.init();//g" chrome/background.js > $@

--- a/webextensions/Makefile
+++ b/webextensions/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean packages install_dependency lint format install_hook testee testee/chrome.js testee/edge.js
+.PHONY: clean packages install_dependency lint format install_hook
 
 NPM_MOD_DIR := $(CURDIR)/node_modules
 NPM_BIN_DIR := $(NPM_MOD_DIR)/.bin

--- a/webextensions/Makefile
+++ b/webextensions/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean packages install_dependency lint format install_hook
+.PHONY: clean packages install_dependency lint format install_hook testee testee/chrome.js testee/edge.js
 
 NPM_MOD_DIR := $(CURDIR)/node_modules
 NPM_BIN_DIR := $(NPM_MOD_DIR)/.bin
@@ -6,7 +6,7 @@ NPM_BIN_DIR := $(NPM_MOD_DIR)/.bin
 all: packages
 
 testee:
-	mkdir $@
+	mkdir -p $@
 
 testee/chrome.js: edge/background.js testee
 	sed -e "s/ThinBridgeTalkClient.init();/exports.client = ThinBridgeTalkClient/g" -e "s/ResourceCap.init();//g" chrome/background.js > $@

--- a/webextensions/chrome/background.js
+++ b/webextensions/chrome/background.js
@@ -400,6 +400,12 @@ const ThinBridgeTalkClient = {
       tabs.forEach((tab) => {
         const url = tab.url || tab.pendingUrl;
         console.log(`handleStartup ${url} (tab=${tab.id})`);
+
+        if (this.checkRedirectIntervalLimit(tab.id, url)) {
+          console.log(`A request for same URL and same tabId already occurred in ${REDIRECT_INTERVAL_LIMIT} msec. Skip it.`);
+          return;
+        }
+
         if (!this.handleURLAndBlock(config, tab.id, url, true))
           this.knownTabIds.add(tab.id);
       });

--- a/webextensions/chrome/background.js
+++ b/webextensions/chrome/background.js
@@ -178,6 +178,14 @@ const ThinBridgeTalkClient = {
         return;
       }
 
+      // Callers need to call checkRedirectIntervalLimit() by themselves on their
+      // own responsibility to avoid duplicated redirections.
+      // We cannot call checkRedirectIntervalLimit() here to see the result,
+      // because some listeners need to see the result of checkRedirectIntervalLimit()
+      // to skip their further operation and they call this method after that.
+      // All redirections will be blocked unexpectedly even when it is really first time,
+      // if we call checkRedirectIntervalLimit() here...
+
       const query = new String('Q ' + BROWSER + ' ' + url);
       console.log(`Redirector: redirecting with message: ${query}`);
       await chrome.runtime.sendNativeMessage(SERVER_NAME, query);

--- a/webextensions/chrome/background.js
+++ b/webextensions/chrome/background.js
@@ -110,8 +110,8 @@ const ThinBridgeTalkClient = {
     const query = new String('C ' + BROWSER);
 
     const resp = await chrome.runtime.sendNativeMessage(SERVER_NAME, query);
-    if (chrome.runtime.lastError) {
-      console.log('Cannot fetch config', JSON.stringify(chrome.runtime.lastError));
+    if (chrome.runtime.lastError || !resp) {
+      console.log('Cannot fetch config', query, JSON.stringify(chrome.runtime.lastError));
       return;
     }
     const isStartup = (this.cached == null);
@@ -168,7 +168,7 @@ const ThinBridgeTalkClient = {
    * * Request Example: "Q edge https://example.com/".
    */
   redirect(url, tabId, closeTab) {
-    chrome.tabs.get(tabId).then(async tab => {
+    return chrome.tabs.get(tabId).then(async tab => {
       if (chrome.runtime.lastError) {
         console.log(`* Ignore prefetch request`);
         return;
@@ -179,6 +179,7 @@ const ThinBridgeTalkClient = {
       }
 
       const query = new String('Q ' + BROWSER + ' ' + url);
+      console.log(`Redirector: redirecting with message: ${query}`);
       await chrome.runtime.sendNativeMessage(SERVER_NAME, query);
 
       if (!closeTab)

--- a/webextensions/chrome/manifest.json
+++ b/webextensions/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 3,
 	"name": "ThinBridge",
-	"version": "2.3.0",
+	"version": "2.3.1",
 	"description": "ThinBridge for Chrome",
 	"permissions": [
 		"nativeMessaging",

--- a/webextensions/edge/background.js
+++ b/webextensions/edge/background.js
@@ -400,6 +400,12 @@ const ThinBridgeTalkClient = {
       tabs.forEach((tab) => {
         const url = tab.url || tab.pendingUrl;
         console.log(`handleStartup ${url} (tab=${tab.id})`);
+
+        if (this.checkRedirectIntervalLimit(tab.id, url)) {
+          console.log(`A request for same URL and same tabId already occurred in ${REDIRECT_INTERVAL_LIMIT} msec. Skip it.`);
+          return;
+        }
+
         if (!this.handleURLAndBlock(config, tab.id, url, true))
           this.knownTabIds.add(tab.id);
       });

--- a/webextensions/edge/background.js
+++ b/webextensions/edge/background.js
@@ -110,8 +110,8 @@ const ThinBridgeTalkClient = {
     const query = new String('C ' + BROWSER);
 
     const resp = await chrome.runtime.sendNativeMessage(SERVER_NAME, query);
-    if (chrome.runtime.lastError) {
-      console.log('Cannot fetch config', JSON.stringify(chrome.runtime.lastError));
+    if (chrome.runtime.lastError || !resp) {
+      console.log('Cannot fetch config', query, JSON.stringify(chrome.runtime.lastError));
       return;
     }
     const isStartup = (this.cached == null);

--- a/webextensions/edge/background.js
+++ b/webextensions/edge/background.js
@@ -178,6 +178,14 @@ const ThinBridgeTalkClient = {
         return;
       }
 
+      // Callers need to call checkRedirectIntervalLimit() by themselves on their
+      // own responsibility to avoid duplicated redirections.
+      // We cannot call checkRedirectIntervalLimit() here to see the result,
+      // because some listeners need to see the result of checkRedirectIntervalLimit()
+      // to skip their further operation and they call this method after that.
+      // All redirections will be blocked unexpectedly even when it is really first time,
+      // if we call checkRedirectIntervalLimit() here...
+
       const query = new String('Q ' + BROWSER + ' ' + url);
       console.log(`Redirector: redirecting with message: ${query}`);
       await chrome.runtime.sendNativeMessage(SERVER_NAME, query);

--- a/webextensions/edge/background.js
+++ b/webextensions/edge/background.js
@@ -168,7 +168,7 @@ const ThinBridgeTalkClient = {
    * * Request Example: "Q edge https://example.com/".
    */
   redirect(url, tabId, closeTab) {
-    chrome.tabs.get(tabId).then(async tab => {
+    return chrome.tabs.get(tabId).then(async tab => {
       if (chrome.runtime.lastError) {
         console.log(`* Ignore prefetch request`);
         return;
@@ -179,6 +179,7 @@ const ThinBridgeTalkClient = {
       }
 
       const query = new String('Q ' + BROWSER + ' ' + url);
+      console.log(`Redirector: redirecting with message: ${query}`);
       await chrome.runtime.sendNativeMessage(SERVER_NAME, query);
 
       if (!closeTab)

--- a/webextensions/edge/manifest.json
+++ b/webextensions/edge/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 3,
 	"name": "__MSG_extName__",
-	"version": "2.3.0",
+	"version": "2.3.1",
 	"description": "__MSG_extDescription__",
 	"permissions": [
 		"nativeMessaging",

--- a/webextensions/test/chrome-stub.js
+++ b/webextensions/test/chrome-stub.js
@@ -1,36 +1,36 @@
 global.chrome = {
     alarms: {
-	create: function() {
-	},
-	onAlarm: {
-	    addListener: function() {
-	    }
-	},
+        create: function() {
+        },
+        onAlarm: {
+            addListener: function() {
+            }
+        },
     },
     runtime: {
-	sendNativeMessage: function() {
-	},
+        sendNativeMessage: function() {
+        },
     },
     tabs: {
-	onCreated: {
-	    addListener: function() {
-	    }
-	},
-	onUpdated: {
-	    addListener: function() {
-	    }
-	},
+        onCreated: {
+            addListener: function() {
+            }
+        },
+        onUpdated: {
+            addListener: function() {
+            }
+        },
     },
     webRequest: {
-	onBeforeRequest: {
-	    addListener: function() {
-	    },
-	},
+        onBeforeRequest: {
+            addListener: function() {
+            },
+        },
     },
     webNavigation: {
-	onCommitted: {
-	    addListener: function() {
-	    }
-	},
+        onCommitted: {
+            addListener: function() {
+            }
+        },
     },
 };

--- a/webextensions/test/chrome-stub.js
+++ b/webextensions/test/chrome-stub.js
@@ -1,36 +1,48 @@
+function createStubMethod(name) {
+  return ((...args) => {
+    //console.log(`called: ${name}`, args, new Error().stack);
+  });
+}
+
 global.chrome = {
     alarms: {
-        create: function() {
-        },
+        create: createStubMethod('alarms.create'),
         onAlarm: {
-            addListener: function() {
-            }
+            addListener: createStubMethod('alarms.onAlarm.addListener'),
         },
     },
     runtime: {
-        sendNativeMessage: function() {
-        },
+        sendNativeMessage: createStubMethod('runtime.sendNativeMessage'),
+        lastError: null,
     },
     tabs: {
         onCreated: {
-            addListener: function() {
-            }
+            addListener: createStubMethod('tabs.onCreated.addListener'),
         },
         onUpdated: {
-            addListener: function() {
-            }
+            addListener: createStubMethod('tabs.onUpdated.addListener'),
         },
+        query: createStubMethod('tabs.query'),
+        get: createStubMethod('tabs.get'),
+        remove: createStubMethod('tabs.remove'),
     },
     webRequest: {
         onBeforeRequest: {
-            addListener: function() {
-            },
+            addListener: createStubMethod('webRequest.onBeforeRequest.addListener'),
         },
     },
     webNavigation: {
         onCommitted: {
-            addListener: function() {
-            }
+            addListener: createStubMethod('webNavigation.onCommitted.addListener'),
         },
+    },
+    storage: {
+      session: {
+        get: createStubMethod('storage.session.get'),
+        set: createStubMethod('storage.session.set'),
+      },
+    },
+    scripting: {
+        executeScript: createStubMethod('tabs.remove'),
     },
 };

--- a/webextensions/test/test-avoid-duplicate-redirect.js
+++ b/webextensions/test/test-avoid-duplicate-redirect.js
@@ -1,0 +1,100 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const chromestub = require('./chrome-stub.js')
+
+describe('avoidDuplicateRedirect', () => {
+  const redirectors = [
+    { browser: 'chrome', module: require('../testee/chrome.js') },
+    { browser: 'edge',   module: require('../testee/edge.js')   },
+  ].forEach(({browser, module}) => {
+    function isEdge() {
+      return browser == "edge";
+    }
+    describe(browser, () => {
+      const thinbridge = module.client;
+      const tabId = 123;
+      let clock;
+
+      beforeEach(() => {
+        clock = sinon.useFakeTimers();
+        thinbridge.recentRequests = {};
+      });
+
+      afterEach(() => {
+        delete thinbridge.recentRequests;
+        clock.restore();
+        sinon.restore();
+      });
+
+      const config = {
+        CloseEmptyTab: 1,
+        DefaultBrowser: isEdge() ? "Chrome" : "Edge",
+        IgnoreQueryString: 1,
+        OnlyMainFrame : 1,
+        Sections: [
+          {
+            "Name": "edge",
+            "Patterns": [isEdge() ? "https://www.clear-code.com/*" : "*://*"],
+            "Excludes": [],
+          },
+          {
+            "Name": "chrome",
+            "Patterns": [isEdge() ? "*://*" : "https://www.clear-code.com/*"],
+            "Excludes": [],
+          },
+        ],
+      };
+
+      const tab = {
+        id: tabId,
+        windowId: 1,
+        url: 'https://example.com/',
+        status: 'complete',
+      };
+
+      const SERVER_NAME = 'com.clear_code.thinbridge';
+
+      it('handleStartup => onTabUpdated', async () => {
+        const sendNativeMessageStub = sinon.stub(chrome.runtime, 'sendNativeMessage')
+          .resolves({ config });
+
+        sinon.stub(chrome.tabs, 'query').resolves([tab]);
+        sinon.stub(chrome.tabs, 'get')
+          .resolves(null)
+          .onCall(0).resolves(tab)
+          .onCall(1).resolves(tab);
+        sinon.stub(chrome.tabs, 'remove').resolves(true);
+        sinon.stub(chrome.storage.session, 'get').resolves({ newTabIds: null, knownTabIds: null });
+
+        thinbridge.cached = config;
+        await thinbridge.handleStartup(config);
+        await thinbridge.onTabUpdated(tabId, { url: tab.url }, { ...tab });
+        await Promise.resolve(true); // We need to wait until all async operations are finished
+
+        const redirectMessage = new String(`Q ${browser} ${tab.url}`);
+        assert.equal(sendNativeMessageStub.withArgs(SERVER_NAME, redirectMessage).callCount, 1);
+     });
+
+      it('onTabUpdated => handleStartup', async () => {
+        const sendNativeMessageStub = sinon.stub(chrome.runtime, 'sendNativeMessage')
+          .resolves({ config });
+
+        sinon.stub(chrome.tabs, 'query').resolves([tab]);
+        sinon.stub(chrome.tabs, 'get')
+          .resolves(null)
+          .onCall(0).resolves(tab)
+          .onCall(1).resolves(tab);
+        sinon.stub(chrome.tabs, 'remove').resolves(true);
+        sinon.stub(chrome.storage.session, 'get').resolves({ newTabIds: null, knownTabIds: null });
+
+        thinbridge.cached = config;
+        await thinbridge.onTabUpdated(tabId, { url: tab.url }, { ...tab });
+        await thinbridge.handleStartup(config);
+        await Promise.resolve(true); // We need to wait until all async operations are finished
+
+        const redirectMessage = new String(`Q ${browser} ${tab.url}`);
+        assert.equal(sendNativeMessageStub.withArgs(SERVER_NAME, redirectMessage).callCount, 1);
+     });
+    });
+  });
+});


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

On the extension startup, onTabUpdated listener can be called before handleStartup. On such cases same URL will be redirected to another browser twice. This PR blocks such a duplicated redirection.

# How to verify the fixed issue:

## The steps to verify:

1. Clone this repository.
2. `cd webextensions`
3. `npm install --save-dev`
4. `make test`

## Expected result:

It passes all tests.