### PR TITLE
Allow to call the native messaging host by locally hosted edge extension

### DIFF
--- a/Resources/edge.json
+++ b/Resources/edge.json
@@ -6,6 +6,7 @@
   "allowed_origins": [
     "chrome-extension://famoofbkcpjdkihdngnhgbdfkfenhcnf/",
     "chrome-extension://knldjmfmopnpolahpmmgbagdohdnhkik/",
-    "chrome-extension://loigjahhocfdkpoikniacpfbhailfkfi/"
+    "chrome-extension://loigjahhocfdkpoikniacpfbhailfkfi/",
+    "chrome-extension://jcamehnjflombcdhafhiogbojgghefec/"
   ]
 }


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

This adds the ID of the Edge extension which is locally hosted.

# How to verify the fixed issue:

## The steps to verify:

1. Install the Edge extension which is locally hosted (via GPO).
2. Install ThinBridge built with this change.
3. Start Edge with debug log (`--enable-logging`).
4. Exit Edge and find the log file `chrome_debug.log` under `%localappdata%\microsoft\edge\user data`.

## Expected result:

The log file `chrome_debug.log` contains logs from an addon with the ID `jcamehnjflombcdhafhiogbojgghefec` and it says that the addon successfully loaded configs via the native messaging host.