### PR TITLE
Release v4.2.1.1

### DIFF
--- a/BHORedirector/BHORedirector.rc
+++ b/BHORedirector/BHORedirector.rc
@@ -58,8 +58,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 4,2,1,0
- PRODUCTVERSION 4,2,1,0
+ FILEVERSION 4,2,1,1
+ PRODUCTVERSION 4,2,1,1
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -76,12 +76,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "ThinBridge"
             VALUE "FileDescription", "ThinBridge"
-            VALUE "FileVersion", "4.2.1.0"
+            VALUE "FileVersion", "4.2.1.1"
             VALUE "InternalName", "ThinBridgeBHO.dll"
             VALUE "LegalCopyright", "ThinBridge All rights reserved."
             VALUE "OriginalFilename", "ThinBridgeBHO.dll"
             VALUE "ProductName", "ThinBridge Browser Helper"
-            VALUE "ProductVersion", "4.2.1.0"
+            VALUE "ProductVersion", "4.2.1.1"
         END
     END
     BLOCK "VarFileInfo"

--- a/TBRedirector/TBRedirector.rc
+++ b/TBRedirector/TBRedirector.rc
@@ -77,8 +77,8 @@ IDR_MAINFRAME           ICON                    "res\\TBRedirector.ico"
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 4,2,1,0
- PRODUCTVERSION 4,2,1,0
+ FILEVERSION 4,2,1,1
+ PRODUCTVERSION 4,2,1,1
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -94,10 +94,10 @@ BEGIN
         BLOCK "041104b0"
         BEGIN
             VALUE "FileDescription", "TBRedirector"
-            VALUE "FileVersion", "4.2.1.0"
+            VALUE "FileVersion", "4.2.1.1"
             VALUE "InternalName", "TBRedirector.exe"
             VALUE "OriginalFilename", "TBRedirector.exe"
-            VALUE "ProductVersion", "4.2.1.0"
+            VALUE "ProductVersion", "4.2.1.1"
         END
     END
     BLOCK "VarFileInfo"

--- a/TBo365URLSync/TBo365URLSync.rc
+++ b/TBo365URLSync/TBo365URLSync.rc
@@ -169,8 +169,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 4,2,1,0
- PRODUCTVERSION 4,2,1,0
+ FILEVERSION 4,2,1,1
+ PRODUCTVERSION 4,2,1,1
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -187,12 +187,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "ThinBridge"
             VALUE "FileDescription", "TBo365URLSync"
-            VALUE "FileVersion", "4.2.1.0"
+            VALUE "FileVersion", "4.2.1.1"
             VALUE "InternalName", "TBo365URLSync.exe"
             VALUE "LegalCopyright", "ThinBridge"
             VALUE "OriginalFilename", "TBo365URLSync.exe"
             VALUE "ProductName", "TBo365URLSync"
-            VALUE "ProductVersion", "4.2.1.0"
+            VALUE "ProductVersion", "4.2.1.1"
         END
     END
     BLOCK "VarFileInfo"

--- a/ThinBridge/ThinBridge.rc
+++ b/ThinBridge/ThinBridge.rc
@@ -196,7 +196,7 @@ FONT 9, "MS UI Gothic", 0, 0, 0x1
 BEGIN
     GROUPBOX        "全般設定",IDC_STATIC,9,7,430,380
     ICON            IDR_MAINFRAME,IDC_STATIC,311,25,20,20
-    LTEXT           "ThinBridge Version 4.2.1.0",IDC_STATIC_VER,339,32,89,8,SS_NOPREFIX
+    LTEXT           "ThinBridge Version 4.2.1.1",IDC_STATIC_VER,339,32,89,8,SS_NOPREFIX
     GROUPBOX        "【重要】URLマッチングルール全体設定",IDC_STATIC,14,49,381,94
     CONTROL         "クイック判定機能を有効にする (※IE専用機能)",IDC_CHK_GLOVAL_QUICK,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,18,64,156,10
     LTEXT           "注意：\nナビゲーション前イベントを優先的に利用しリダイレクトを高速化します。\nリダイレクト通知画面は表示されません。",IDC_STATIC,18,77,372,32,0,WS_EX_STATICEDGE
@@ -455,8 +455,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 4,2,1,0
- PRODUCTVERSION 4,2,1,0
+ FILEVERSION 4,2,1,1
+ PRODUCTVERSION 4,2,1,1
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -472,10 +472,10 @@ BEGIN
         BLOCK "041104b0"
         BEGIN
             VALUE "FileDescription", "ThinBridgeX-Point"
-            VALUE "FileVersion", "4.2.1.0"
+            VALUE "FileVersion", "4.2.1.1"
             VALUE "InternalName", "ThinBridge.exe"
             VALUE "OriginalFilename", "ThinBridge.exe"
-            VALUE "ProductVersion", "4.2.1.0"
+            VALUE "ProductVersion", "4.2.1.1"
         END
     END
     BLOCK "VarFileInfo"

--- a/ThinBridgeChecker/ThinBridgeChecker.rc
+++ b/ThinBridgeChecker/ThinBridgeChecker.rc
@@ -135,8 +135,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 4,2,1,0
- PRODUCTVERSION 4,2,1,0
+ FILEVERSION 4,2,1,1
+ PRODUCTVERSION 4,2,1,1
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -153,12 +153,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "ThinBridge"
             VALUE "FileDescription", "ThinBridgeChecker"
-            VALUE "FileVersion", "4.2.1.0"
+            VALUE "FileVersion", "4.2.1.1"
             VALUE "InternalName", "ThinBridgeChecker.exe"
             VALUE "LegalCopyright", "ThinBridge"
             VALUE "OriginalFilename", "ThinBridgeChecker.exe"
             VALUE "ProductName", "ThinBridgeChecker"
-            VALUE "ProductVersion", "4.2.1.0"
+            VALUE "ProductVersion", "4.2.1.1"
         END
     END
     BLOCK "VarFileInfo"

--- a/ThinBridgeRuleUpdater/ThinBridgeRuleUpdater.rc
+++ b/ThinBridgeRuleUpdater/ThinBridgeRuleUpdater.rc
@@ -137,8 +137,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 4,2,1,0
- PRODUCTVERSION 4,2,1,0
+ FILEVERSION 4,2,1,1
+ PRODUCTVERSION 4,2,1,1
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -155,12 +155,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "ThinBridge"
             VALUE "FileDescription", "ThinBridgeRuleUpdater"
-            VALUE "FileVersion", "4.2.1.0"
+            VALUE "FileVersion", "4.2.1.1"
             VALUE "InternalName", "ThinBridgeRuleUpdater.exe"
             VALUE "LegalCopyright", "ThinBridge"
             VALUE "OriginalFilename", "ThinBridgeRuleUpdater.exe"
             VALUE "ProductName", "ThinBridgeRuleUpdater"
-            VALUE "ProductVersion", "4.2.1.0"
+            VALUE "ProductVersion", "4.2.1.1"
         END
     END
     BLOCK "VarFileInfo"

--- a/ThinBridgeX64.iss
+++ b/ThinBridgeX64.iss
@@ -3,8 +3,8 @@
 [Setup]
 AppName=ThinBridge
 AppVerName=ThinBridge
-VersionInfoVersion=4.2.1.0
-AppVersion=4.2.1.0
+VersionInfoVersion=4.2.1.1
+AppVersion=4.2.1.1
 AppMutex=ThinBridgeSetup
 ;DefaultDirName=C:\ThinBridge
 DefaultDirName={code:GetProgramFiles}\ThinBridge
@@ -24,7 +24,7 @@ UninstallDisplayIcon={app}\ThinBridge.exe
 Root: HKLM; Subkey: "Software\ThinBridge"; Flags: uninsdeletekey
 Root: HKLM; Subkey: "Software\ThinBridge"; ValueType: string; ValueName: "Path"; ValueData: "{app}\"
 Root: HKLM; Subkey: "Software\ThinBridge"; ValueType: string; ValueName: "ClientType"; ValueData: ""
-Root: HKLM; Subkey: "Software\ThinBridge"; ValueType: string; ValueName: "Version"; ValueData: "4.2.1.0"
+Root: HKLM; Subkey: "Software\ThinBridge"; ValueType: string; ValueName: "Version"; ValueData: "4.2.1.1"
 Root: HKLM; Subkey: "Software\ThinBridge"; ValueType: string; ValueName: "Rulefile"; ValueData: "{app}\ThinBridgeBHO.ini"
 Root: HKLM; Subkey: "Software\ThinBridge"; ValueType: string; ValueName: "RCAPfile"; ValueData: "{app}\ResourceCap.ini"
 Root: HKLM; Subkey: "Software\ThinBridge"; ValueType: string; ValueName: "ExtensionExecfile"; ValueData: "{app}\TBRedirector.exe"
@@ -32,7 +32,7 @@ Root: HKLM; Subkey: "Software\ThinBridge"; ValueType: string; ValueName: "Extens
 Root: HKLM; Subkey: "Software\WOW6432Node\ThinBridge"; Flags: uninsdeletekey
 Root: HKLM; Subkey: "Software\WOW6432Node\ThinBridge"; ValueType: string; ValueName: "Path"; ValueData: "{app}\"
 Root: HKLM; Subkey: "Software\WOW6432Node\ThinBridge"; ValueType: string; ValueName: "ClientType"; ValueData: ""
-Root: HKLM; Subkey: "Software\WOW6432Node\ThinBridge"; ValueType: string; ValueName: "Version"; ValueData: "4.2.1.0"
+Root: HKLM; Subkey: "Software\WOW6432Node\ThinBridge"; ValueType: string; ValueName: "Version"; ValueData: "4.2.1.1"
 Root: HKLM; Subkey: "Software\WOW6432Node\ThinBridge"; ValueType: string; ValueName: "Rulefile"; ValueData: "{app}\ThinBridgeBHO.ini"
 Root: HKLM; Subkey: "Software\WOW6432Node\ThinBridge"; ValueType: string; ValueName: "RCAPfile"; ValueData: "{app}\ResourceCap.ini"
 Root: HKLM; Subkey: "Software\WOW6432Node\ThinBridge"; ValueType: string; ValueName: "ExtensionExecfile"; ValueData: "{app}\TBRedirector.exe"

--- a/ThinBridgeX86.iss
+++ b/ThinBridgeX86.iss
@@ -3,8 +3,8 @@
 [Setup]
 AppName=ThinBridge
 AppVerName=ThinBridge
-VersionInfoVersion=4.2.1.0
-AppVersion=4.2.1.0
+VersionInfoVersion=4.2.1.1
+AppVersion=4.2.1.1
 AppMutex=ThinBridgeSetup
 ;DefaultDirName=C:\ThinBridge
 DefaultDirName={code:GetProgramFiles}\ThinBridge
@@ -24,7 +24,7 @@ UninstallDisplayIcon={app}\ThinBridge.exe
 Root: HKLM; Subkey: "Software\ThinBridge"; Flags: uninsdeletekey
 Root: HKLM; Subkey: "Software\ThinBridge"; ValueType: string; ValueName: "Path"; ValueData: "{app}\"
 Root: HKLM; Subkey: "Software\ThinBridge"; ValueType: string; ValueName: "ClientType"; ValueData: ""
-Root: HKLM; Subkey: "Software\ThinBridge"; ValueType: string; ValueName: "Version"; ValueData: "4.2.1.0"
+Root: HKLM; Subkey: "Software\ThinBridge"; ValueType: string; ValueName: "Version"; ValueData: "4.2.1.1"
 Root: HKLM; Subkey: "Software\ThinBridge"; ValueType: string; ValueName: "Rulefile"; ValueData: "{app}\ThinBridgeBHO.ini"
 Root: HKLM; Subkey: "Software\ThinBridge"; ValueType: string; ValueName: "RCAPfile"; ValueData: "{app}\ResourceCap.ini"
 Root: HKLM; Subkey: "Software\ThinBridge"; ValueType: string; ValueName: "ExtensionExecfile"; ValueData: "{app}\TBRedirector.exe"
@@ -32,7 +32,7 @@ Root: HKLM; Subkey: "Software\ThinBridge"; ValueType: string; ValueName: "Extens
 ;Root: HKLM; Subkey: "Software\WOW6432Node\ThinBridge"; Flags: uninsdeletekey
 ;Root: HKLM; Subkey: "Software\WOW6432Node\ThinBridge"; ValueType: string; ValueName: "Path"; ValueData: "{app}\"
 ;Root: HKLM; Subkey: "Software\WOW6432Node\ThinBridge"; ValueType: string; ValueName: "ClientType"; ValueData: ""
-;Root: HKLM; Subkey: "Software\WOW6432Node\ThinBridge"; ValueType: string; ValueName: "Version"; ValueData: "4.2.1.0"
+;Root: HKLM; Subkey: "Software\WOW6432Node\ThinBridge"; ValueType: string; ValueName: "Version"; ValueData: "4.2.1.1"
 ;Root: HKLM; Subkey: "Software\WOW6432Node\ThinBridge"; ValueType: string; ValueName: "Rulefile"; ValueData: "{app}\ThinBridgeBHO.ini"
 ;Root: HKLM; Subkey: "Software\WOW6432Node\ThinBridge"; ValueType: string; ValueName: "ExtensionExecfile"; ValueData: "{app}\TBRedirector.exe"
 


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

This bumps the version number to 4.2.1.1.
It should be released as: https://github.com/ThinBridge/ThinBridge/releases/tag/v4.2.1.1

# How to verify the fixed issue:

## The steps to verify:

1. Build binaries.
2. See the version number.

## Expected result:

It is 4.2.1.1.