### PR TITLE
Don't redirect URLs too frequently for safety (interval=1sec)

### DIFF
--- a/webextensions/test/test-avoid-duplicate-redirect.js
+++ b/webextensions/test/test-avoid-duplicate-redirect.js
@@ -67,12 +67,12 @@ describe('avoidDuplicateRedirect', () => {
         sinon.stub(chrome.storage.session, 'get').resolves({ newTabIds: null, knownTabIds: null });
 
         thinbridge.cached = config;
+        thinbridge.queuedRedirectionURLs = [];
         await thinbridge.handleStartup(config);
         await thinbridge.onTabUpdated(tabId, { url: tab.url }, { ...tab });
         await Promise.resolve(true); // We need to wait until all async operations are finished
 
-        const redirectMessage = new String(`Q ${browser} ${tab.url}`);
-        assert.equal(sendNativeMessageStub.withArgs(SERVER_NAME, redirectMessage).callCount, 1);
+        assert.equal(JSON.stringify(thinbridge.queuedRedirectionURLs), JSON.stringify([tab.url]));
      });
 
       it('onTabUpdated => handleStartup', async () => {
@@ -88,12 +88,12 @@ describe('avoidDuplicateRedirect', () => {
         sinon.stub(chrome.storage.session, 'get').resolves({ newTabIds: null, knownTabIds: null });
 
         thinbridge.cached = config;
+        thinbridge.queuedRedirectionURLs = [];
         await thinbridge.onTabUpdated(tabId, { url: tab.url }, { ...tab });
         await thinbridge.handleStartup(config);
         await Promise.resolve(true); // We need to wait until all async operations are finished
 
-        const redirectMessage = new String(`Q ${browser} ${tab.url}`);
-        assert.equal(sendNativeMessageStub.withArgs(SERVER_NAME, redirectMessage).callCount, 1);
+        assert.equal(JSON.stringify(thinbridge.queuedRedirectionURLs), JSON.stringify([tab.url]));
      });
     });
   });


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

Too frequent call of the native messaging host for redirections may cause troubles.
This throttles such redirections and process them with 1 second interval.

# How to verify the fixed issue:

## The steps to verify:

1. Configure ThinBridge with some redirection rules.
2. Start a browser.
3. Load a page which includes multiple subframes with URLs to be redirected.

## Expected result:

Redirections are processed step by step with 1 second interval.