### PR TITLE
Log enhancement

### DIFF
--- a/ThinBridgeRuleUpdater/ThinBridgeRuleUpdater.cpp
+++ b/ThinBridgeRuleUpdater/ThinBridgeRuleUpdater.cpp
@@ -608,6 +608,7 @@ CString CThinBridgeRuleUpdaterApp::WriteThinBridgeBHO(CConfData* pSettingConf,BO
 		}
 	}
 
+	strRet += LogFmt(_T("設定データ取得開始"));
 	//GUIからの場合
 	if(bFromGUI)
 	{
@@ -742,7 +743,9 @@ CString CThinBridgeRuleUpdaterApp::WriteThinBridgeBHO(CConfData* pSettingConf,BO
 		}
 	}
 	strRet += TBRuleUpdate.GetLog();
+	strRet += LogFmt(_T("設定データ取得完了"));
 
+	strRet += LogFmt(_T("設定データ差分確認開始"));
 	//ThinBridgeBHOのデータを全て読み込む
 	CStdioFile in;
 	CString strTemp;
@@ -808,7 +811,7 @@ CString CThinBridgeRuleUpdaterApp::WriteThinBridgeBHO(CConfData* pSettingConf,BO
 			}
 		}
 	}
-
+	strRet += LogFmt(_T("設定データ差分確認完了"));
 	//変更あり
 	if(bDiff)
 	{
@@ -916,8 +919,10 @@ CString CThinBridgeRuleUpdaterApp::WriteThinBridgeBHO(CConfData* pSettingConf,BO
 		CString strTemp1;
 		strTemp1 = strRet;
 		strRet =_T("【同一内容 変更なし】\r\n更新内容に差分がありませんでした。\r\n");
-		strTemp1.Format(_T("取得元：%s\r\n更新先：%s\r\n"), strConfigServerURL, m_strThinBridgeBHOFileFullPath);
+		CString strTemp2;
+		strTemp2.Format(_T("取得元：%s\r\n更新先：%s\r\n"), strConfigServerURL, m_strThinBridgeBHOFileFullPath);
 		strRet += strServerIndex;
+		strRet += strTemp2;
 		strRet += strTemp1;
 		m_iWriteThinBridgeBHO_ResultCode=SUCCESS_SAME_DATA;
 	}


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

Added logs to check a download time of setting files and a process time of diff check.

Also fixed a bug that some logs are not written when there is no diff in a setting file.

# How to verify the fixed issue:
## The steps to verify:

* Add `C:\Temp\ThinBridgeBHO.ini` (copy from default file)
* Set `C:\Temp\ThinBridgeBHO.ini` as target setting file from ThinBridgeRuleUpdaterSetting.exe
* Execute ThinBridgeRuleUpdater.exe multiple times (in order to get result "no diff").
* Check the last execution logs.
  * [x] Confirm that detailed logs are written even when there is no diff.
  * [x] Confirm that added logs are written (the logs marked `★` in the following logs).
```
自動更新//////////////////////////////////////////////////////////////////////////////////////////////////
2025-10-08 10:54:35
処理結果：成功：全ての処理に成功しました 差分なし SUCCESS_SAME_DATA
ExecUser:[TH-NOTE-PC/hashi]LogonUser:[TH-NOTE-PC/hashi]LogonUserSID:[S-1-5-21-2560384222-3494138830-2531760485-1001]CurrentSID:[S-1-5-21-2560384222-3494138830-2531760485-1001]
SettingType:File
【同一内容 変更なし】
更新内容に差分がありませんでした。
取得元：C:\Temp\ThinBridgeBHO.ini
更新先：C:\gitdir\ThinBridge\Debug\ThinBridgeBHO.ini
ThinBridgeRuleUpdater	2025-10-08 10:54:35	設定データ取得開始 ★
ThinBridgeRuleUpdater	2025-10-08 10:54:36	1:OK 200 OK_SERVER C:\Temp\ThinBridgeBHO.ini
ThinBridgeRuleUpdater	2025-10-08 10:54:35	>>>ExecMain
ThinBridgeRuleUpdater	2025-10-08 10:54:35	>>>GetThinBridgeRedirectRuleCIFS C:\Temp\ThinBridgeBHO.ini
ThinBridgeRuleUpdater	2025-10-08 10:54:35	
>>>>>>>>>>
...
<<<<<<<<<<
ThinBridgeRuleUpdater	2025-10-08 10:54:35	<<<GetThinBridgeRedirectRuleCIFS OK_SERVER
ThinBridgeRuleUpdater	2025-10-08 10:54:35	>>>ExecMain
ThinBridgeRuleUpdater	2025-10-08 10:54:36	設定データ取得完了 ★
ThinBridgeRuleUpdater	2025-10-08 10:54:36	設定データ差分確認開始 ★
ThinBridgeRuleUpdater	2025-10-08 10:54:38	設定データ差分確認完了 ★
```
