### PR TITLE
Fix typo in Ansible playbook definition

### DIFF
--- a/doc/verify/windows-11-22H2/main.tf
+++ b/doc/verify/windows-11-22H2/main.tf
@@ -622,7 +622,7 @@ resource "local_file" "playbook" {
     - name: Install Edge from Installer
       when: not "${var.edge-installer-download-url}" == ""
       win_command: 'msiexec /i C:\Users\Public\EdgeSetup.msi /passive /norestart'
-      ignore_erros: yes
+      ignore_errors: yes
     - name: Disable Edge Update Service (edgeupdate)
       when: not "${var.edge-installer-download-url}" == ""
       win_service:


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

This fixes a typo in Ansible playbook definition for Windows 11 VM.

# How to verify the fixed issue:

## The steps to verify:

1. `cd doc/verify/windows-11-22H2`
2. `make`

## Expected result:

A testing environment is prepared with no error.