### PR TITLE
Fix typo in Ansible playbook

### DIFF
--- a/doc/verify/windows-10-1809/main.tf
+++ b/doc/verify/windows-10-1809/main.tf
@@ -591,7 +591,7 @@ resource "local_file" "playbook" {
     - name: Install Edge from Installer
       when: not "${var.edge-installer-download-url}" == ""
       win_command: 'msiexec /i C:\Users\Public\EdgeSetup.msi /passive /norestart'
-      ignore_erros: yes
+      ignore_errors: yes
     - name: Disable Edge Update Service (edgeupdate)
       when: not "${var.edge-installer-download-url}" == ""
       win_service:

--- a/doc/verify/windows-10-21H2/main.tf
+++ b/doc/verify/windows-10-21H2/main.tf
@@ -618,7 +618,7 @@ resource "local_file" "playbook" {
     - name: Install Edge from Installer
       when: not "${var.edge-installer-download-url}" == ""
       win_command: 'msiexec /i C:\Users\Public\EdgeSetup.msi /passive /norestart'
-      ignore_erros: yes
+      ignore_errors: yes
     - name: Disable Edge Update Service (edgeupdate)
       when: not "${var.edge-installer-download-url}" == ""
       win_service:


### PR DESCRIPTION
# Which issue(s) this PR fixes:

N/A

# What this PR does / why we need it:

This fixes a typo in Ansible playbooks.

# How to verify the fixed issue:

## The steps to verify:

1. `cd` to `doc/verify/windows-10-21H2` or `doc/verify/windows-10-1809`.
2. Run `make`.

## Expected result:

Azure VM successfully prepared with no error in Ansible playbook.